### PR TITLE
Don't escape sql names unless required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for beam-automigrate
 
+## 0.1.1.0
+
+* Escape sql identifiers only when required by the [postgres syntax rules](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)
+
 ## 0.1.0.1
 
 * Loosen time version bounds

--- a/beam-automigrate.cabal
+++ b/beam-automigrate.cabal
@@ -1,5 +1,5 @@
 name:               beam-automigrate
-version:            0.1.0.1
+version:            0.1.1.0
 license-file:       LICENSE
 build-type:         Simple
 cabal-version:      >=1.10

--- a/src/Database/Beam/AutoMigrate/Util.hs
+++ b/src/Database/Beam/AutoMigrate/Util.hs
@@ -8,6 +8,7 @@ import Control.Monad.Except
 import Data.Functor.Constant
 import Data.String (fromString)
 import Data.Text (Text)
+import qualified Data.Text as T
 import Database.Beam.AutoMigrate.Types (ColumnName (..), TableName (..))
 import Database.Beam.Schema (Beamable, PrimaryKey, TableEntity, TableSettings)
 import qualified Database.Beam.Schema as Beam
@@ -104,7 +105,7 @@ sqlOptCharSet Nothing = mempty
 sqlOptCharSet (Just cs) = " CHARACTER SET " <> cs
 
 sqlEscaped :: Text -> Text
-sqlEscaped t = "\"" <> t <> "\""
+sqlEscaped t = if T.toLower t == t then t else "\"" <> t <> "\""
 
 sqlSingleQuoted :: Text -> Text
 sqlSingleQuoted t = "'" <> t <> "'"


### PR DESCRIPTION
Prior to this, beam-automigrate would often generate unnecessary migrations based on diffs that only differed in unnecessary escaping. For example, this schema should require no migration:

```
Schema {schemaTables = fromList [(TableName {tableName = "db_accounts"},Table {tableConstraints = fromList [PrimaryKey "db_accounts_pkey" (fromList [ColumnName {columnName = "account_id"}])], tableColumns = fromList [(ColumnName {columnName = "account_email"},Column {columnType = SqlStdType (DataTypeChar True Nothing Nothing), columnConstraints = fromList [NotNull]}),(ColumnName {columnName = "account_id"},Column {columnType = SqlStdType DataTypeInteger, columnConstraints = fromList [NotNull,Default "nextval('db_accounts___account_id___seq'::regclass)"]}),(ColumnName {columnName = "account_passwordHash"},Column {columnType = SqlStdType DataTypeBinaryLargeObject, columnConstraints = fromList []}),(ColumnName {columnName = "account_passwordResetNonce"},Column {columnType = SqlStdType (DataTypeTimeStamp Nothing True), columnConstraints = fromList []})]}),(TableName {tableName = "db_posts"},Table {tableConstraints = fromList [PrimaryKey "db_posts_pkey" (fromList [ColumnName {columnName = "post_id"}])], tableColumns = fromList [(ColumnName {columnName = "post_body"},Column {columnType = SqlStdType (DataTypeChar True Nothing Nothing), columnConstraints = fromList [NotNull]}),(ColumnName {columnName = "post_id"},Column {columnType = SqlStdType DataTypeInteger, columnConstraints = fromList [NotNull,Default "nextval('db_posts___post_id___seq'::regclass)"]}),(ColumnName {columnName = "post_timestamp"},Column {columnType = SqlStdType (DataTypeTimeStamp Nothing True), columnConstraints = fromList [NotNull]}),(ColumnName {columnName = "post_title"},Column {columnType = SqlStdType (DataTypeChar True Nothing Nothing), columnConstraints = fromList [NotNull]})]})], schemaEnumerations = fromList [], schemaSequences = fromList [(SequenceName {seqName = "db_accounts___account_id___seq"},Sequence {seqTable = TableName {tableName = "db_accounts"}, seqColumn = ColumnName {columnName = "account_id"}}),(SequenceName {seqName = "db_posts___post_id___seq"},Sequence {seqTable = TableName {tableName = "db_posts"}, seqColumn = ColumnName {columnName = "post_id"}})]}
```

But we generate these migrations:

```
Database migration required, attempting...
        ALTER TABLE "db_accounts" ALTER COLUMN "account_id" SET DEFAULT nextval('"db_accounts___account_id___seq"'::regclass);

        ALTER TABLE "db_accounts" ALTER COLUMN "account_id" DROP DEFAULT;

        ALTER TABLE "db_posts" ALTER COLUMN "post_id" SET DEFAULT nextval('"db_posts___post_id___seq"'::regclass);

        ALTER TABLE "db_posts" ALTER COLUMN "post_id" DROP DEFAULT;

```

`"nextval('db_accounts___account_id___seq'::regclass)"` in the schema and `nextval('"db_accounts___account_id___seq"'::regclass` in the migration differ only in the double-quotes.