### PR TITLE
Add build flag for the README executable stanza

### DIFF
--- a/beam-automigrate.cabal
+++ b/beam-automigrate.cabal
@@ -211,6 +211,9 @@ executable readme
   main-is: README.lhs
   ghc-options: -Wall -optL -q
 
+  if !flag(build-readme)
+    buildable: False
+
 flag werror
   description: Enable -Werror during development
   default:     False
@@ -223,6 +226,11 @@ flag ghcipretty
 
 flag integration-tests
   description: Enable integration tests that talks to a Postgres DB.
+  default:     False
+  manual:      True
+
+flag build-readme
+  description: Build README.lhs which depends on gargoyle
   default:     False
   manual:      True
 


### PR DESCRIPTION
Fixes issue #16.  Gargoyle only appears to be used in the README executable stanza.  Haskell build tools tend to treat executable stanzas as belonging to the project, so it seems like we need a build flag to control this.