### PR TITLE
Add IsString TableName instance

### DIFF
--- a/src/Database/Beam/AutoMigrate/Types.hs
+++ b/src/Database/Beam/AutoMigrate/Types.hs
@@ -101,6 +101,9 @@ newtype TableName = TableName
   }
   deriving (Show, Eq, Ord, NFData, Generic)
 
+instance IsString TableName where
+  fromString = TableName . T.pack
+
 data Table = Table
   { tableConstraints :: Set TableConstraint,
     tableColumns :: Columns


### PR DESCRIPTION
There's `IsString ColumnName`, so I guess this one was just forgotten?