### PR TITLE
Print updated migration

### DIFF
--- a/src/Database/Beam/AutoMigrate.hs
+++ b/src/Database/Beam/AutoMigrate.hs
@@ -269,6 +269,11 @@ runMigrationWithEditUpdate editUpdate conn hsSchema = do
   -- If the new list of edits still contains any unsafe edits then fail out.
   when (any (editSafetyIs Unsafe . fst . unPriority) newEdits) $
     throwIO $ UnsafeEditsDetected $ fmap (\(WithPriority (e, _)) -> _editAction e) newEdits
+
+  when (newEdits /= edits) $ do
+    putStrLn "Changes requested to diff induced migration. Attempting..."
+    prettyPrintEdits newEdits
+
   -- Execute all the edits within a single transaction so we rollback if any of them fail.
   Pg.withTransaction conn $
     Pg.runBeamPostgres conn $
@@ -659,6 +664,9 @@ prettyEditActionDescription =
     pshow' :: Show a => a -> Text
     pshow' = LT.toStrict . PS.pShow
 
+prettyPrintEdits :: [WithPriority Edit] -> IO ()
+prettyPrintEdits edits = putStrLn $ T.unpack $ T.unlines $ fmap (prettyEditSQL . fst . unPriority) (sortEdits edits)
+
 -- | Compare the existing schema in the database with the expected
 -- schema in Haskell and try to edit the existing schema as necessary
 tryRunMigrationsWithEditUpdate
@@ -689,7 +697,7 @@ tryRunMigrationsWithEditUpdate annotatedDb conn = do
         putStrLn "No database migration required, continuing startup."
       Right edits -> do
         putStrLn "Database migration required, attempting..."
-        putStrLn $ T.unpack $ T.unlines $ fmap (prettyEditSQL . fst . unPriority) (sortEdits edits)
+        prettyPrintEdits edits
 
         try (runMigrationWithEditUpdate Prelude.id conn expectedHaskellSchema) >>= \case
           Left (e :: SomeException) ->


### PR DESCRIPTION
On top of #30.
Currently there's no way to see the actual migration steps that beam-automigrate will actually run, only the ones obtained from diffing the schemas.
