### PR TITLE
Export GDefaultTableSchema

### DIFF
--- a/src/Database/Beam/AutoMigrate/Annotated.hs
+++ b/src/Database/Beam/AutoMigrate/Annotated.hs
@@ -24,6 +24,7 @@ module Database.Beam.AutoMigrate.Annotated
     dbAnnotatedConstraints,
     annotatedDescriptor,
     defaultTableSchema,
+    GDefaultTableSchema(..),
 
     -- * Downcasting annotated types
     lowerEntityDescriptor,


### PR DESCRIPTION
cc @kmicklas
Not sure if this can be fixed in a simpler way, but I had need of this symbol in a project to add an instance for the `Id` type from [beam-keyed](https://github.com/kmicklas/beam-keyed). IIRC this only happened with Nullable foreign keys.


```haskell
instance HasColumnType (K.Id tbl1) => GDefaultTableSchema
  (S1 f (K1 R (IdKeyT tbl1 (Nullable (TableFieldSchema tbl2)))) ())
  (S1 f (K1 R (IdKeyT tbl1 (Nullable (TableField tbl2)))) ())
  where
  gDefTblSchema (_ :: Proxy (S1 f (K1 R (IdKeyT tbl1 (Nullable (TableFieldSchema tbl2)))) ())) (M1 (K1 fName)) =
    M1 (K1 $ to' $ gDefTblSchema Proxy (from' fName))
```

as otherwise
```
    • No instance for (GDefaultTableSchema
                         (M1
                            S
                            ('MetaSel
                               ('Just "_rowKey_data")
                               'NoSourceUnpackedness
                               'NoSourceStrictness
                               'DecidedLazy)
                            (Rec0
                               (IdKeyT
                                  MyTableFooT
                                  (Nullable (TableFieldSchema (KeyedT MyTableBarT)))))
                            ())
                         (M1
                            S
                            ('MetaSel
                               ('Just "_rowKey_data")
                               'NoSourceUnpackedness
                               'NoSourceStrictness
                               'DecidedLazy)
                            (Rec0
                               (IdKeyT
                                  MyTableFooT
                                  (Nullable (TableField (KeyedT MyTableBarT)))))
                            ()))
        arising from a use of ‘tryRunMigrationsWithEditUpdate’
```