### PR TITLE
More robust constraint/sequence diffing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ hie.yaml
 *.prof
 .stack-work
 cabal.project.freeze
+
+readme-db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 * Major overhaul in how constraints and sequences are diffed
   * haskell/database constraints are now diffed based on *what* they constrain; instead of being an exact match.  inconsequential differences (in particular, the names of constraints, in most cases) no longer require any expensive DML.
   * Sequences ownership is now handled with the `OWNED BY table_name.column_name` mechanism instead of parsing the owner out of the sequence name.  unowned sequences (which might be used for purposes other than surrogate keys, for example) are still supported internally.
-  * beam-automigrate will now allow postgres to choose the names of constraints and sequences when possible.  In cases where that's not possible or desired, there is now a straitforward mechanism for end users to specify the name explicitly (see `foreignKeyWithOptions`).
-  * constraint options are always optional, with `Default` instances for `UniqueConstraintOptions` and `ForeignKeyConstraintOptions`.  As of this writing, the defaults currenlty mean "let postgres decide" for constraint names and cascade behaviors (the latter being NO ACTION).
+  * beam-automigrate will now allow postgres to choose the names of constraints and sequences when possible.  In cases where that's not possible or desired, there is now a straightforward mechanism for end users to specify the name explicitly (see `foreignKeyWithOptions`).
+  * constraint options are always optional, with `Default` instances for `UniqueConstraintOptions` and `ForeignKeyConstraintOptions`.  As of this writing, the defaults currently mean "let postgres decide" for constraint names and cascade behaviors (the latter being NO ACTION).
   * Foreign keys can now be configured to reference columns that are different from the table's primary key.  in general this feature is much easier to use; passing a function that projects out the desired columns from both tables.
-  * foreign keys can now be partially nullable. (see foreignKeyOnNullable)
+  * foreign keys can now be partially nullable. (see `foreignKeyOnNullable`)
   * Many instances of database entities being dropped and recreated instead of altered are now supported.
 * [#47](https://github.com/obsidiansystems/beam-automigrate/pull/47): Generate postgres enum types in schema when using `Nullable PgEnum` values.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+* Major overhaul in how constraints and sequences are diffed
+  * haskell/database constraints are now diffed based on *what* they constrain; instead of being an exact match.  inconsequential differences (in particular, the names of constraints, in most cases) no longer require any expensive DML.
+  * Sequences ownership is now handled with the `OWNED BY table_name.column_name` mechanism instead of parsing the owner out of the sequence name.  unowned sequences (which might be used for purposes other than surrogate keys, for example) are still supported internally.
+  * beam-automigrate will now allow postgres to choose the names of constraints and sequences when possible.  In cases where that's not possible or desired, there is now a straitforward mechanism for end users to specify the name explicitly (see `foreignKeyWithOptions`).
+  * constraint options are always optional, with `Default` instances for `UniqueConstraintOptions` and `ForeignKeyConstraintOptions`.  As of this writing, the defaults currenlty mean "let postgres decide" for constraint names and cascade behaviors (the latter being NO ACTION).
+  * Foreign keys can now be configured to reference columns that are different from the table's primary key.  in general this feature is much easier to use; passing a function that projects out the desired columns from both tables.
+  * foreign keys can now be partially nullable. (see foreignKeyOnNullable)
+  * Many instances of database entities being dropped and recreated instead of altered are now supported.
 * [#47](https://github.com/obsidiansystems/beam-automigrate/pull/47): Generate postgres enum types in schema when using `Nullable PgEnum` values.
 
 ## 0.1.3.0

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Deriving an `AnnotatedDatabaseSettings` for a Haskell database type is a matter 
 > import Prelude hiding ((.))
 > import Control.Category ((.))
 > import Data.Proxy (Proxy(..))
+> import Data.Default.Class (def)
 > import Database.Beam.Postgres
 > import Database.Beam.Schema
 > import Database.Beam (val_)
@@ -132,7 +133,7 @@ ambiguity). To do this, we can piggyback on the familiar API from `beam-core`. F
 >       BA.annotateTableFields tableModification { ctCapital = BA.defaultsTo $ val_ False }
 >         <> BA.uniqueConstraintOn [BA.U ctCity, BA.U ctLocation]
 >   , dbWeathers = BA.annotateTableFields tableModification <>
->       BA.foreignKeyOnPk (dbCities defaultDbSettings) wtCity BA.Cascade BA.Restrict
+>       BA.foreignKeyOnPkWithOptions (dbCities defaultDbSettings) wtCity def { onDelete = BA.Cascade, onUpdate = BA.Restrict}
 >   }
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,18 +9,19 @@ Automatic migrations for [beam](https://hackage.haskell.org/package/beam-core) d
 Table of Contents
 -----------------
 
-* [Table of Contents](#table-of-contents)
-* [Getting started (User guide/reference)](#getting-started-user-guidereference)
-   * [Deriving an AnnotatedDatabaseSettings](#deriving-an-annotateddatabasesettings)
-   * [Overriding the defaults of an AnnotatedDatabaseSettings](#overriding-the-defaults-of-an-annotateddatabasesettings)
-   * [Deriving a Schema](#deriving-a-schema)
-   * [Generating an automatic migration](#generating-an-automatic-migration)
-* [Current design (10_000ft overview)](#current-design-10_000ft-overview)
-   * [Deriving information from a DatabaseSettings](#deriving-information-from-a-databasesettings)
-   * [Deriving information from an AnnotatedDatabaseSettings](#deriving-information-from-an-annotateddatabasesettings)
-   * [What is implemented](#what-is-implemented)
-   * [Shortcomings and limitations](#shortcomings-and-limitations)
-* [Contributors](#contributors)
+- [beam-automigrate](#beam-automigrate)
+  - [Table of Contents](#table-of-contents)
+- [Getting started (User guide/reference)](#getting-started-user-guidereference)
+  - [Deriving an AnnotatedDatabaseSettings](#deriving-an-annotateddatabasesettings)
+  - [Overriding the defaults of an `AnnotatedDatabaseSettings`](#overriding-the-defaults-of-an-annotateddatabasesettings)
+  - [Deriving a Schema](#deriving-a-schema)
+  - [Generating an automatic migration](#generating-an-automatic-migration)
+- [Current design (10_000ft overview)](#current-design-10_000ft-overview)
+  - [Deriving information from a DatabaseSettings](#deriving-information-from-a-databasesettings)
+  - [Deriving information from an AnnotatedDatabaseSettings](#deriving-information-from-an-annotateddatabasesettings)
+  - [What is implemented](#what-is-implemented)
+  - [Shortcomings and limitations](#shortcomings-and-limitations)
+- [Contributors](#contributors)
 
 Getting started (User guide/reference)
 ======================================
@@ -62,14 +63,14 @@ Deriving an `AnnotatedDatabaseSettings` for a Haskell database type is a matter 
 > import Prelude hiding ((.))
 > import Control.Category ((.))
 > import Data.Proxy (Proxy(..))
-> import Data.Default.Class (def)
 > import Database.Beam.Postgres
 > import Database.Beam.Schema
-> import Database.Beam (val_)
+> import Database.Beam (val_, primaryKey)
 > import qualified Database.Beam.AutoMigrate as BA
 > import Database.Beam.AutoMigrate.TestUtils
 > import Database.PostgreSQL.Simple as Pg
 > import GHC.Generics
+> import Data.Default.Class
 > import Data.Text
 > import System.Environment (getArgs)
 >
@@ -133,7 +134,7 @@ ambiguity). To do this, we can piggyback on the familiar API from `beam-core`. F
 >       BA.annotateTableFields tableModification { ctCapital = BA.defaultsTo $ val_ False }
 >         <> BA.uniqueConstraintOn [BA.U ctCity, BA.U ctLocation]
 >   , dbWeathers = BA.annotateTableFields tableModification <>
->       BA.foreignKeyOnPkWithOptions (dbCities defaultDbSettings) wtCity def { onDelete = BA.Cascade, onUpdate = BA.Restrict}
+>       BA.foreignKeyOnWithOptions (dbCities defaultDbSettings) wtCity primaryKey def { BA.onDelete = BA.Cascade, BA.onUpdate = BA.Restrict}
 >   }
 
 ```

--- a/beam-automigrate.cabal
+++ b/beam-automigrate.cabal
@@ -37,6 +37,7 @@ library
     Database.Beam.AutoMigrate.Types
     Database.Beam.AutoMigrate.Util
     Database.Beam.AutoMigrate.Validity
+    Database.Beam.AutoMigrate.Parser
 
   hs-source-dirs:     src
   build-depends:
@@ -48,7 +49,6 @@ library
     , containers            >=0.5.9.2  && <0.8.0.0
     , deepseq               >=1.4.4    && <1.6
     , dlist                 >=0.8.0    && <1.1
-    , microlens             >=0.4.10   && <0.6
     , mtl                   >=2.2.2    && <2.4
     , postgresql-simple     >=0.5.4    && <0.7.0.0
     , pretty-simple         >=2.2.0    && <4.2
@@ -62,6 +62,10 @@ library
     , transformers          >=0.5.6    && <0.7
     , uuid                  >=1.3      && <1.4
     , vector                >=0.12.0.3 && <0.13.0.0
+    , lens
+    , data-default-class
+    , attoparsec
+    , parsers
 
   default-language:   Haskell2010
   default-extensions:
@@ -153,6 +157,7 @@ executable beam-automigrate-examples
     , beam-core
     , beam-postgres
     , bytestring
+    , data-default-class
     , postgresql-simple
     , text
     , time
@@ -218,6 +223,8 @@ executable readme
     , beam-automigrate-test-utils
     , beam-core
     , beam-postgres
+    , data-default-class
+    , gargoyle-postgresql-connect
     , postgresql-simple
     , text
   default-language: Haskell2010

--- a/examples/Example.hs
+++ b/examples/Example.hs
@@ -14,6 +14,7 @@ module Example where
 import Control.Exception
 import Data.Aeson.TH
 import Data.ByteString (ByteString)
+import Data.Default.Class
 import Data.Int (Int32, Int64)
 import Data.Proxy
 import Data.Text (Text)
@@ -32,6 +33,8 @@ import Database.Beam.AutoMigrate
     migrate,
     printMigration,
     unsafeRunMigration,
+    onUpdate,
+    onDelete,
   )
 import Database.Beam.AutoMigrate.Annotated
 import Database.Beam.AutoMigrate.Postgres (getSchema)
@@ -208,7 +211,7 @@ annotatedDB =
               { orderTime = defaultsTo currentTimestamp_,
                 orderValidity = defaultsTo (range_ Inclusive Inclusive (val_ $ Just 10) (val_ $ Just 20))
               }
-            <> foreignKeyOnPk (dbFlowers flowerDB) orderFlowerIdRef Cascade Restrict
+            <> foreignKeyOnWithOptions (dbFlowers flowerDB) orderFlowerIdRef primaryKey (def { onUpdate = Cascade, onDelete = Restrict })
             <> uniqueConstraintOn [U (addressPostalCode . addressRegion . orderAddress)]
             --, dbLineItemsTwo = foreignKeyOn (dbLineItems flowerDB) [
             --                          lineItemTwoFk `References` LineItemID

--- a/integration-tests/Main.hs
+++ b/integration-tests/Main.hs
@@ -82,12 +82,15 @@ instance NormalizeDefaultExprs Table where
   normalizeDefaultExprs t = t { tableColumns = Map.map normalizeDefaultExprs (tableColumns t)}
 
 instance NormalizeDefaultExprs Column where
-  normalizeDefaultExprs c = c { columnConstraints = Set.map normalizeDefaultExprs (columnConstraints c) }
+  normalizeDefaultExprs c = c { columnConstraints = normalizeDefaultExprs (columnConstraints c) }
 
-instance NormalizeDefaultExprs ColumnConstraint where
+instance NormalizeDefaultExprs ColumnConstraints where
+  normalizeDefaultExprs c =  c { columnDefault = fmap normalizeDefaultExprs (columnDefault c) }
+
+instance NormalizeDefaultExprs DefaultConstraint where
   normalizeDefaultExprs = \case
-    NotNull -> NotNull
-    Default t -> Default (normalizeDefaultExpr t)
+    DefaultExpr t -> DefaultExpr $ normalizeDefaultExpr t
+    Autoincrement mseq -> Autoincrement mseq
 
 normalizeDefaultExpr :: Text -> Text
 normalizeDefaultExpr t = case PgParsing.run PgParsing.aExpr t of

--- a/integration-tests/Main.hs
+++ b/integration-tests/Main.hs
@@ -23,7 +23,6 @@ import Data.Generics.Aliases (mkT)
 import Data.Generics.Schemes (everywhere)
 import Data.Int
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
 import PostgresqlSyntax.Ast

--- a/src/Database/Beam/AutoMigrate.hs
+++ b/src/Database/Beam/AutoMigrate.hs
@@ -406,6 +406,7 @@ toSqlSyntax e =
               NotNull -> " SET NOT NULL"
           )
       ColumnDefaultChanged tblName colName dfltConst ->
+        if dfltConst == Just (Autoincrement Nothing) then updateSyntax "DO $$ BEGIN END; $$" else -- On Autoincrement Nothing, renderColumnDefault generates an empty string, which causes invalid syntax.  We can just skip this statement entirely, in that case.  If we just put an empty string, we get QueryError {qeMessage = "execute: Empty query", qeQuery = "        "}, so we need to put this useless DO statement in here; probably this function should return Maybe or a list or something like that instead
         updateSyntax
           ( alterTable tblName <> "ALTER COLUMN "
             <> sqlEscaped (columnName colName)

--- a/src/Database/Beam/AutoMigrate.hs
+++ b/src/Database/Beam/AutoMigrate.hs
@@ -410,7 +410,7 @@ toSqlSyntax e =
           ( alterTable tblName <> "ALTER COLUMN "
             <> sqlEscaped (columnName colName)
             <> case dfltConst of
-              Nothing -> " DROP DEFAULT"
+              Nothing -> " DROP DEFAULT "
               Just d -> " SET " <> renderColumnDefault d
           )
     EditAction_Manual ea -> case ea of
@@ -582,7 +582,7 @@ renderDataTypeAdd col =
   in mconcat
     [ dataType
     , case columnNullable $ columnConstraints col of
-      NotNull -> " NOT NULL"
+      NotNull -> " NOT NULL "
       Null -> " "
     , foldMap renderColumnDefault $ columnDefault $ columnConstraints col
 
@@ -595,7 +595,7 @@ renderDataTypeAdd col =
 renderColumnDefault :: DefaultConstraint -> Text
 renderColumnDefault = \case
   Autoincrement Nothing -> "" -- Don't render the default, use "serial/bigserial" as tye type instead
-  defValue -> "DEFAULT " <> case defValue of
+  defValue -> " DEFAULT " <> case defValue of
     DefaultExpr defValueExpr -> defValueExpr
     Autoincrement x -> flip foldMap x $ \(SequenceName sName) ->
       "nextval(" <> sqlSingleQuoted sName <> "::regclass)"

--- a/src/Database/Beam/AutoMigrate.hs
+++ b/src/Database/Beam/AutoMigrate.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
+{-# OPTIONS_GHC -Wall -Werror #-}
+
 -- | This module provides the high-level API to migrate a database.
 module Database.Beam.AutoMigrate
   ( -- * Annotating a database
@@ -92,7 +94,7 @@ import Database.Beam.Schema (Database, DatabaseSettings)
 import Database.Beam.Schema.Tables (DatabaseEntity (..))
 import qualified Database.PostgreSQL.Simple as Pg
 import GHC.Generics hiding (prec)
-import Lens.Micro (over, (^.), _1, _2)
+import Control.Lens (over, (^.), _1, _2)
 import qualified Text.Pretty.Simple as PS
 
 -- $annotatingDbSettings
@@ -344,17 +346,30 @@ toSqlSyntax e =
         ddlSyntax
           ( "CREATE TABLE " <> sqlEscaped (tableName tblName)
               <> " ("
-              <> T.intercalate ", " (map renderTableColumn (M.toList (tableColumns tbl)))
+              <> T.intercalate ", " (map renderTableAddedColumn (M.toList (tableColumns tbl)))
               <> ")"
           )
       TableRemoved tblName ->
         ddlSyntax ("DROP TABLE " <> sqlEscaped (tableName tblName))
-      TableConstraintAdded tblName cstr ->
-        updateSyntax (alterTable tblName <> renderAddConstraint cstr)
+      PrimaryKeyAdded tblName cstr copt ->
+        updateSyntax (alterTable tblName <> " ADD " <> renderCreatePrimaryKeyConstraint cstr copt)
+      UniqueConstraintAdded tblName cstr copt ->
+        updateSyntax (alterTable tblName <> " ADD " <> renderCreateUniqueConstraint cstr copt)
+      ForeignKeyAdded tblName cstr copt ->
+        updateSyntax (alterTable tblName <> " ADD " <> renderCreateForeignKeyConstraint cstr copt)
+
+      RenameConstraint tblName (ConstraintName oldName) (ConstraintName newName) ->
+        updateSyntax (alterTable tblName
+          <> " RENAME CONSTRAINT "
+          <> sqlEscaped oldName
+          <> " TO "
+          <> sqlEscaped newName)
       TableConstraintRemoved tblName cstr ->
         updateSyntax (alterTable tblName <> renderDropConstraint cstr)
-      SequenceAdded sName (Sequence _tName _cName) -> createSequenceSyntax sName
+      SequenceAdded sName s -> createSequenceSyntax sName s
       SequenceRemoved sName -> dropSequenceSyntax sName
+      SequenceRenamed oldName newName -> renameSequenceSyntax oldName newName
+      SequenceSetOwner sName newOwner -> setSequenceOwnerSyntax sName newOwner
       EnumTypeAdded tyName vals -> createTypeSyntax tyName vals
       EnumTypeRemoved (EnumerationName tyName) -> ddlSyntax ("DROP TYPE " <> tyName)
       EnumTypeValueAdded (EnumerationName tyName) newVal order insPoint ->
@@ -373,9 +388,10 @@ toSqlSyntax e =
               <> "ADD COLUMN "
               <> sqlEscaped (columnName colName)
               <> " "
-              <> renderDataType (columnType col)
-              <> " "
-              <> T.intercalate " " (map (renderColumnConstraint SetConstraint) (S.toList $ columnConstraints col))
+              <> renderDataTypeAdd col
+              -- <> " "
+              -- <> renderAddColumnConstraint col
+              -- <> T.intercalate " " (map (renderColumnConstraint SetConstraint) (S.toList $ columnConstraints col))
           )
       ColumnRemoved tblName colName ->
         updateSyntax (alterTable tblName <> "DROP COLUMN " <> sqlEscaped (columnName colName))
@@ -386,19 +402,21 @@ toSqlSyntax e =
               <> " TYPE "
               <> renderDataType new
           )
-      ColumnConstraintAdded tblName colName cstr ->
+      ColumnNullableChanged tblName colName nullConstr ->
         updateSyntax
           ( alterTable tblName <> "ALTER COLUMN "
-              <> sqlEscaped (columnName colName)
-              <> " SET "
-              <> renderColumnConstraint SetConstraint cstr
+            <> sqlEscaped (columnName colName)
+            <> case nullConstr of
+              Null -> " DROP NOT NULL"
+              NotNull -> " SET NOT NULL"
           )
-      ColumnConstraintRemoved tblName colName cstr ->
+      ColumnDefaultChanged _ tblName colName dfltConst ->
         updateSyntax
           ( alterTable tblName <> "ALTER COLUMN "
-              <> sqlEscaped (columnName colName)
-              <> " DROP "
-              <> renderColumnConstraint DropConstraint cstr
+            <> sqlEscaped (columnName colName)
+            <> case dfltConst of
+              Nothing -> " DROP DEFAULT"
+              Just d -> " SET " <> renderColumnDefault d
           )
     EditAction_Manual ea -> case ea of
       ColumnRenamed tblName oldName newName ->
@@ -420,35 +438,36 @@ toSqlSyntax e =
     alterTable :: TableName -> Text
     alterTable (TableName tName) = "ALTER TABLE " <> sqlEscaped tName <> " "
 
-    renderTableColumn :: (ColumnName, Column) -> Text
-    renderTableColumn (colName, col) =
+    renderTableAddedColumn :: (ColumnName, Column) -> Text
+    renderTableAddedColumn (colName, col) =
       sqlEscaped (columnName colName) <> " "
-        <> renderDataType (columnType col)
-        <> " "
-        <> T.intercalate " " (map (renderColumnConstraint SetConstraint) (S.toList $ columnConstraints col))
+        <> renderDataTypeAdd col
+        -- <> " "
+        -- <> T.intercalate " " (map (renderColumnConstraint SetConstraint) (S.toList $ columnConstraints col))
 
     renderInsertionOrder :: InsertionOrder -> Text
     renderInsertionOrder Before = "BEFORE"
     renderInsertionOrder After = "AFTER"
 
-    renderCreateTableConstraint :: TableConstraint -> Text
-    renderCreateTableConstraint = \case
-      Unique fname cols ->
-        conKeyword <> sqlEscaped fname
+    renderCreateUniqueConstraint :: Unique -> UniqueConstraintOptions -> Text
+    renderCreateUniqueConstraint (Unique cols) (UniqueConstraintOptions fname) =
+        conKeyword fname
           <> " UNIQUE ("
           <> T.intercalate ", " (map (sqlEscaped . columnName) (S.toList cols))
           <> ")"
-      PrimaryKey fname cols ->
-        conKeyword <> sqlEscaped fname
+    renderCreatePrimaryKeyConstraint :: PrimaryKeyConstraint -> UniqueConstraintOptions -> Text
+    renderCreatePrimaryKeyConstraint (PrimaryKey cols) (UniqueConstraintOptions fname) =
+        conKeyword fname
           <> " PRIMARY KEY ("
           <> T.intercalate ", " (map (sqlEscaped . columnName) (S.toList cols))
           <> ")"
-      ForeignKey fname (tableName -> tName) (S.toList -> colPair) onDelete onUpdate ->
+    renderCreateForeignKeyConstraint :: ForeignKey -> ForeignKeyConstraintOptions -> Text
+    renderCreateForeignKeyConstraint (ForeignKey (tableName -> tName) (S.toList -> colPair)) constr  =
         let (fkCols, referenced) =
               ( map (sqlEscaped . columnName . fst) colPair,
                 map (sqlEscaped . columnName . snd) colPair
               )
-         in conKeyword <> sqlEscaped fname
+         in conKeyword (foreignKeyConstraintName constr)
               <> " FOREIGN KEY ("
               <> T.intercalate ", " fkCols
               <> ") REFERENCES "
@@ -456,21 +475,18 @@ toSqlSyntax e =
               <> "("
               <> T.intercalate ", " referenced
               <> ")"
-              <> renderAction "ON DELETE" onDelete
-              <> renderAction "ON UPDATE" onUpdate
-      where
-        conKeyword = "CONSTRAINT "
+              <> renderAction "ON DELETE" (onDelete constr)
+              <> renderAction "ON UPDATE" (onUpdate constr)
 
-    renderAddConstraint :: TableConstraint -> Text
-    renderAddConstraint = mappend "ADD " . renderCreateTableConstraint
+    conKeyword = \case
+      Nothing -> ""
+      Just (ConstraintName fname) -> "CONSTRAINT " <> sqlEscaped fname
 
-    renderDropConstraint :: TableConstraint -> Text
-    renderDropConstraint tc = case tc of
-      Unique cName _ -> dropC cName
-      PrimaryKey cName _ -> dropC cName
-      ForeignKey cName _ _ _ _ -> dropC cName
-      where
-        dropC = mappend "DROP CONSTRAINT " . sqlEscaped
+    -- renderAddConstraint :: TableConstraint -> Text
+    -- renderAddConstraint = mappend "ADD " . renderCreateTableConstraint
+
+    renderDropConstraint :: ConstraintName -> Text
+    renderDropConstraint = mappend "DROP CONSTRAINT " . sqlEscaped . unConsraintName
 
     renderAction actionPrefix = \case
       NoAction -> mempty
@@ -479,11 +495,15 @@ toSqlSyntax e =
       SetNull -> " " <> actionPrefix <> " " <> "SET NULL "
       SetDefault -> " " <> actionPrefix <> " " <> "SET DEFAULT "
 
-    renderColumnConstraint :: AlterTableAction -> ColumnConstraint -> Text
-    renderColumnConstraint act = \case
-      NotNull -> "NOT NULL"
-      Default defValue | act == SetConstraint -> "DEFAULT " <> defValue
-      Default _ -> "DEFAULT"
+    -- renderColumnConstraint :: AlterTableAction -> ColumnConstraint -> Text
+    -- renderColumnConstraint act = \case
+    --   NotNull -> "NOT NULL"
+    --   Default (Autoincrement Nothing) -> "" -- Don't render the default, use "serial/bigserial" as tye type instead
+    --   Default defValue | act == SetConstraint -> "DEFAULT " <> case defValue of
+    --     DefaultExpr defValueExpr -> defValueExpr
+    --     Autoincrement x -> flip foldMap x $ \(SequenceName sName) ->
+    --       "nextval(" <> sqlSingleQuoted sName <> "::regclass)"
+    --   Default _ -> "DEFAULT"
 
     createTypeSyntax :: EnumerationName -> Enumeration -> Pg.PgSyntax
     createTypeSyntax (EnumerationName ty) (Enumeration vals) =
@@ -491,8 +511,30 @@ toSqlSyntax e =
         toS $
           "CREATE TYPE " <> ty <> " AS ENUM (" <> T.intercalate "," (map sqlSingleQuoted vals) <> ");\n"
 
-    createSequenceSyntax :: SequenceName -> Pg.PgSyntax
-    createSequenceSyntax (SequenceName s) = Pg.emit $ toS $ "CREATE SEQUENCE " <> sqlEscaped s <> ";\n"
+    createSequenceSyntax :: SequenceName -> Maybe Sequence -> Pg.PgSyntax
+    createSequenceSyntax (SequenceName sName) sOwner = Pg.emit $ toS
+      $ "CREATE SEQUENCE " <> sqlEscaped sName
+      <> sequenceOwnerSyntax sOwner
+      <> ";\n"
+
+    renameSequenceSyntax :: SequenceName -> SequenceName -> Pg.PgSyntax
+    renameSequenceSyntax (SequenceName sName) (SequenceName sName') = Pg.emit $ toS
+      $ "ALTER SEQUENCE " <> sqlEscaped sName
+      <> "RENAME TO " <> sqlEscaped sName'
+      <> ";\n"
+
+    setSequenceOwnerSyntax :: SequenceName -> Maybe Sequence -> Pg.PgSyntax
+    setSequenceOwnerSyntax (SequenceName sName) sOwner = Pg.emit $ toS
+      $ "ALTER SEQUENCE " <> sqlEscaped sName
+      <> sequenceOwnerSyntax sOwner
+      <> ";\n"
+
+
+    sequenceOwnerSyntax :: Maybe Sequence -> Text
+    sequenceOwnerSyntax sOwner = " OWNED BY " <> case sOwner of
+      Nothing -> " NONE "
+      Just (Sequence (tableName -> tName) (columnName -> cName)) ->
+        sqlEscaped tName <> "." <> sqlEscaped cName
 
     dropSequenceSyntax :: SequenceName -> Pg.PgSyntax
     dropSequenceSyntax (SequenceName s) = Pg.emit $ toS $ "DROP SEQUENCE " <> sqlEscaped s <> ";\n"
@@ -546,6 +588,40 @@ renderStdType = \case
     wTz withTz tt prec =
       tt <> sqlOptPrec prec <> (if withTz then " WITH" else " WITHOUT") <> " TIME ZONE"
 
+-- -- as a special case, when adding a column, we can potentially specify SERIAL, and save some effort creating a name for a sequence and setting it's ownership up.k
+renderDataTypeAdd :: Column -> Text
+renderDataTypeAdd col =
+  let
+    autoIncrement = Just (Autoincrement Nothing) == columnDefault (columnConstraints col)
+    dataType = case (autoIncrement, (columnType col)) of
+      (False, cType) -> renderDataType cType
+      (True, SqlStdType AST.DataTypeInteger) -> " SERIAL "
+      (True, SqlStdType AST.DataTypeSmallInt) -> " SMALLSERIAL "
+      (True, SqlStdType AST.DataTypeBigInt) -> " BIGSERIAL "
+      (True, dtype) -> error $ "inferred illegal autoincrement column: " <> show dtype
+  in mconcat
+    [ dataType
+    , case columnNullable $ columnConstraints col of
+      NotNull -> " NOT NULL"
+      Null -> " "
+    , foldMap renderColumnDefault $ columnDefault $ columnConstraints col
+
+    ]
+
+-- | render the part of a columnconstraint that sets its' default.  This
+-- renders nothing if the sequence name is not known; and so should not be
+-- called if that's possible outside of a context that also adds the column as
+-- a SERIAL type.   It's up to the caller to prefix SET or DROP when needed.
+renderColumnDefault :: DefaultConstraint -> Text
+renderColumnDefault = \case
+  Autoincrement Nothing -> "" -- Don't render the default, use "serial/bigserial" as tye type instead
+  defValue -> "DEFAULT " <> case defValue of
+    DefaultExpr defValueExpr -> defValueExpr
+    Autoincrement x -> flip foldMap x $ \(SequenceName sName) ->
+      "nextval(" <> sqlSingleQuoted sName <> "::regclass)"
+
+
+--
 -- This function also overlaps with beam-migrate functionalities.
 renderDataType :: ColumnType -> Text
 renderDataType = \case
@@ -611,10 +687,16 @@ prettyEditActionDescription = T.unwords . \case
   EditAction_Automatic ea -> case ea of
     TableAdded tblName table ->
       ["create table:", qt tblName, "\n", pshow' table]
+    RenameConstraint tblName oldConstraint newConstraint ->
+      ["constraint ", qn oldConstraint, " on table ", qt tblName," renamed to: ", qn newConstraint]
     TableRemoved tblName ->
       ["remove table:", qt tblName]
-    TableConstraintAdded tblName tableConstraint ->
-      ["add table constraint to:", qt tblName, "\n", pshow' tableConstraint]
+    PrimaryKeyAdded tblName tableConstraint constraintOptions ->
+      ["add table constraint to:", qt tblName, "\n", pshow' tableConstraint, " ", pshow' constraintOptions]
+    UniqueConstraintAdded tblName tableConstraint constraintOptions ->
+      ["add table constraint to:", qt tblName, "\n", pshow' tableConstraint, " ", pshow' constraintOptions]
+    ForeignKeyAdded tblName tableConstraint constraintOptions ->
+      ["add table constraint to:", qt tblName, "\n", pshow' tableConstraint, " ", pshow' constraintOptions]
     TableConstraintRemoved tblName tableConstraint ->
       ["remove table constraint from:", qt tblName, "\n", pshow' tableConstraint]
     ColumnAdded tblName colName column ->
@@ -631,22 +713,26 @@ prettyEditActionDescription = T.unwords . \case
         "\nto:",
         renderDataType newColumnType
       ]
-    ColumnConstraintAdded tblName colName columnConstraint ->
-      [ "add column constraint to:",
-        qc colName,
-        "in table:",
-        qt tblName,
-        "\n",
-        pshow' columnConstraint
-      ]
-    ColumnConstraintRemoved tblName colName columnConstraint ->
-      [ "remove column constraint from:",
-        qc colName,
-        "in table:",
-        qt tblName,
-        "\n",
-        pshow' columnConstraint
-      ]
+    ColumnNullableChanged tblName colName nullConstr ->
+      ["column:", qq tblName colName, " chanted to ", pshow' nullConstr]
+    ColumnDefaultChanged _ tblName colName dfltConstr ->
+      ["column:", qq tblName colName, " default changed to ", pshow' dfltConstr]
+    -- ColumnConstraintAdded tblName colName columnConstraint ->
+    --   [ "add column constraint to:",
+    --     qc colName,
+    --     "in table:",
+    --     qt tblName,
+    --     "\n",
+    --     pshow' columnConstraint
+    --   ]
+    -- ColumnConstraintRemoved tblName colName columnConstraint ->
+    --   [ "remove column constraint from:",
+    --     qc colName,
+    --     "in table:",
+    --     qt tblName,
+    --     "\n",
+    --     pshow' columnConstraint
+    --   ]
     EnumTypeAdded eName enumeration ->
       ["add enum type:", enumName eName, pshow' enumeration]
     EnumTypeRemoved eName ->
@@ -663,8 +749,12 @@ prettyEditActionDescription = T.unwords . \case
       ]
     SequenceAdded sequenceName sequence0 ->
       ["add sequence:", qs sequenceName, pshow' sequence0]
+    SequenceRenamed sequenceName sequence0 ->
+      ["renamed sequence:", qs sequenceName, " to:", qs sequence0]
     SequenceRemoved sequenceName ->
       ["remove sequence:", qs sequenceName]
+    SequenceSetOwner sequenceName sequence0 ->
+      ["alter sequence:", qs sequenceName, pshow' sequence0]
   EditAction_Manual ea -> case ea of
     ColumnRenamed tblName oldName newName ->
       [ "rename column in table:",
@@ -679,6 +769,8 @@ prettyEditActionDescription = T.unwords . \case
     qt = q . tableName
     qc = q . columnName
     qs = q . seqName
+    qn = q . unConsraintName
+    qq t c = qt t <> "." <> qc c
 
     pshow' :: Show a => a -> Text
     pshow' = LT.toStrict . PS.pShow
@@ -690,25 +782,32 @@ prettyPrintEdits edits = putStrLn $ T.unpack $ T.unlines $ fmap (prettyEditSQL .
 -- schema in Haskell and try to edit the existing schema as necessary
 tryRunMigrationsWithEditUpdate
   :: ( Generic (db (DatabaseEntity be db))
-     , (Generic (db (AnnotatedDatabaseEntity be db)))
+     , Generic (db (AnnotatedDatabaseEntity be db))
      , Database be db
-     , (GZipDatabase be
-         (AnnotatedDatabaseEntity be db)
-         (AnnotatedDatabaseEntity be db)
-         (DatabaseEntity be db)
-         (Rep (db (AnnotatedDatabaseEntity be db)))
-         (Rep (db (AnnotatedDatabaseEntity be db)))
-         (Rep (db (DatabaseEntity be db)))
-       )
-     , (GSchema be db '[] (Rep (db (AnnotatedDatabaseEntity be db))))
+     , GZipDatabase be
+        (AnnotatedDatabaseEntity be db)
+        (AnnotatedDatabaseEntity be db)
+        (DatabaseEntity be db)
+        (Rep (db (AnnotatedDatabaseEntity be db)))
+        (Rep (db (AnnotatedDatabaseEntity be db)))
+        (Rep (db (DatabaseEntity be db)))
+     , GSchema be db '[] (Rep (db (AnnotatedDatabaseEntity be db)))
      )
   => AnnotatedDatabaseSettings be db
   -> Pg.Connection
   -> IO ()
 tryRunMigrationsWithEditUpdate annotatedDb conn = do
+    -- putStrLn "tryRunMigrationsWithEditUpdate START"
+
     let expectedHaskellSchema = fromAnnotatedDbSettings annotatedDb (Proxy @'[])
+    -- putStrLn "tryRunMigrationsWithEditUpdate expectedHaskellSchema"
+    -- putStrLn $ show expectedHaskellSchema
+
     actualDatabaseSchema <- getSchema conn
-    case diff expectedHaskellSchema actualDatabaseSchema of
+    -- putStrLn "tryRunMigrationsWithEditUpdate actualDatabaseSchema"
+    -- putStrLn $ show actualDatabaseSchema
+
+    case fmap sortEdits $ diff expectedHaskellSchema actualDatabaseSchema of
       Left err -> do
         putStrLn "Error detecting database migration requirements: "
         print err

--- a/src/Database/Beam/AutoMigrate.hs
+++ b/src/Database/Beam/AutoMigrate.hs
@@ -362,7 +362,7 @@ toSqlSyntax e =
           <> sqlEscaped oldName
           <> " TO "
           <> sqlEscaped newName)
-      TableConstraintRemoved tblName cstr ->
+      TableConstraintRemoved tblName cstr _ ->
         updateSyntax (alterTable tblName <> renderDropConstraint cstr)
       SequenceAdded sName s -> createSequenceSyntax sName s
       SequenceRemoved sName -> dropSequenceSyntax sName
@@ -677,7 +677,7 @@ prettyEditActionDescription = T.unwords . \case
       ["add table constraint to:", qt tblName, "\n", pshow' tableConstraint, " ", pshow' constraintOptions]
     ForeignKeyAdded tblName tableConstraint constraintOptions ->
       ["add table constraint to:", qt tblName, "\n", pshow' tableConstraint, " ", pshow' constraintOptions]
-    TableConstraintRemoved tblName tableConstraint ->
+    TableConstraintRemoved tblName tableConstraint _ ->
       ["remove table constraint from:", qt tblName, "\n", pshow' tableConstraint]
     ColumnAdded tblName colName column ->
       ["add column:", qc colName, ", from:", qt tblName, "\n", pshow' column]

--- a/src/Database/Beam/AutoMigrate.hs
+++ b/src/Database/Beam/AutoMigrate.hs
@@ -501,7 +501,7 @@ toSqlSyntax e =
     renameSequenceSyntax :: SequenceName -> SequenceName -> Pg.PgSyntax
     renameSequenceSyntax (SequenceName sName) (SequenceName sName') = Pg.emit $ toS
       $ "ALTER SEQUENCE " <> sqlEscaped sName
-      <> "RENAME TO " <> sqlEscaped sName'
+      <> " RENAME TO " <> sqlEscaped sName'
       <> ";\n"
 
     setSequenceOwnerSyntax :: SequenceName -> Maybe Sequence -> Pg.PgSyntax

--- a/src/Database/Beam/AutoMigrate/Annotated.hs
+++ b/src/Database/Beam/AutoMigrate/Annotated.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# OPTIONS_GHC -Wall -Werror #-}
 {-# OPTIONS_GHC -Wno-duplicate-exports #-}
 
 -- | This module provides an 'AnnotatedDatabaseSettings' type to be used as a drop-in replacement for the
@@ -273,9 +272,6 @@ _dbAnnotatedSchema = \a2fb s -> (\b -> s {dbAnnotatedSchema = b}) <$> a2fb (dbAn
 _dbAnnotatedConstraints :: Lens.Lens' (AnnotatedDatabaseEntityDescriptor be (TableEntity tbl)) TableConstraints
 _dbAnnotatedConstraints = \a2fb s -> (\b -> s {dbAnnotatedConstraints = b}) <$> a2fb (dbAnnotatedConstraints s)
 {-# INLINE _dbAnnotatedConstraints #-}
-
-
--- _dbAnnotatedConstraints :: Lens' (AnnotatedDatabaseEntityDescriptor be (TableEntity tbl)) TableConstraints
 
 -- | A 'Getter' to get a plain 'DatabaseEntityDescriptor' from an 'AnnotatedDatabaseEntity'.
 lowerEntityDescriptor :: Getter (AnnotatedDatabaseEntity be db entityType) (DatabaseEntityDescriptor be entityType)
@@ -597,20 +593,6 @@ mkForeignKeyConstraint e ourColumn externalEntity theirColumn =
           (fieldAsColumnNames (theirColumn (tableSettings externalEntity)))
       tName = externalEntity ^. dbEntityDescriptor . dbEntityName
   in ForeignKey (TableName tName) (S.fromList colPairs)
-
-
-        -- ( \(AnnotatedDatabaseEntity tbl@(AnnotatedDatabaseTable {}) e) ->
-        --     AnnotatedDatabaseEntity
-        --       ( tbl
-        --           { dbAnnotatedConstraints =
-        --                   conname = T.intercalate "_" (tName : map (columnName . snd) colPairs) <> "_fkey"
-
-        --                in S.insert
-        --                     (ForeignKey conname (TableName tName) (S.fromList colPairs) onDelete onUpdate)
-        --                     (dbAnnotatedConstraints tbl)
-        --           }
-        --       )
-        --       e
 
 foreignKeyOnWithOptions ::
   ( Beam.Beamable tbl'

--- a/src/Database/Beam/AutoMigrate/Annotated.hs
+++ b/src/Database/Beam/AutoMigrate/Annotated.hs
@@ -52,6 +52,7 @@ module Database.Beam.AutoMigrate.Annotated
     foreignKeyOnPk,
     foreignKeyOn,
     foreignKeyOnNullable,
+    foreignKeyOnWithOptions,
 
     -- * Other types and functions
     TableKind,

--- a/src/Database/Beam/AutoMigrate/Annotated.hs
+++ b/src/Database/Beam/AutoMigrate/Annotated.hs
@@ -577,7 +577,6 @@ foreignKeyOn ::
 foreignKeyOn externalEntity ourColumn theirColumn =
   foreignKeyOnWithOptions externalEntity ourColumn theirColumn def
 
--- mkForeignKeyConstraint :: 
 mkForeignKeyConstraint
   :: (Beam.Beamable key, Beam.Beamable tbl')
   => DatabaseEntity be db (TableEntity tbl)
@@ -609,7 +608,10 @@ foreignKeyOnWithOptions externalEntity ourColumn theirColumn options =
     ( Endo
         ( \(AnnotatedDatabaseEntity tbl@(AnnotatedDatabaseTable {}) e) ->
             AnnotatedDatabaseEntity
-              ( tbl Lens.& Lens.over (_dbAnnotatedConstraints . _foreignKeyConstraints) (<> M.singleton (mkForeignKeyConstraint e ourColumn externalEntity theirColumn) options)
+              ( Lens.over
+                  (_dbAnnotatedConstraints . _foreignKeyConstraints)
+                  (<> M.singleton (mkForeignKeyConstraint e ourColumn externalEntity theirColumn) options)
+                  tbl
               )
               e
         )

--- a/src/Database/Beam/AutoMigrate/BenchUtil.hs
+++ b/src/Database/Beam/AutoMigrate/BenchUtil.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+{-# OPTIONS_GHC -Wall -Werror #-}
+
 module Database.Beam.AutoMigrate.BenchUtil
   ( SpineStrict (..)
   , predictableSchemas

--- a/src/Database/Beam/AutoMigrate/BenchUtil.hs
+++ b/src/Database/Beam/AutoMigrate/BenchUtil.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-{-# OPTIONS_GHC -Wall -Werror #-}
-
 module Database.Beam.AutoMigrate.BenchUtil
   ( SpineStrict (..)
   , predictableSchemas

--- a/src/Database/Beam/AutoMigrate/Compat.hs
+++ b/src/Database/Beam/AutoMigrate/Compat.hs
@@ -3,8 +3,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# OPTIONS_GHC -Wall -Werror #-}
-
 -- | This is a module which adapts and simplifies certain things normally provided by "beam-migrate", but
 --     without the extra complication of importing and using the library itself.
 module Database.Beam.AutoMigrate.Compat where
@@ -23,7 +21,6 @@ import Data.UUID
 import Data.Word
 import qualified Database.Beam as Beam
 import Database.Beam.AutoMigrate.Types
--- import qualified Database.Beam.AutoMigrate.Util as Util
 import Database.Beam.Backend.SQL hiding (tableName)
 import qualified Database.Beam.Backend.SQL.AST as AST
 import qualified Database.Beam.Postgres as Pg

--- a/src/Database/Beam/AutoMigrate/Compat.hs
+++ b/src/Database/Beam/AutoMigrate/Compat.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+{-# OPTIONS_GHC -Wall -Werror #-}
+
 -- | This is a module which adapts and simplifies certain things normally provided by "beam-migrate", but
 --     without the extra complication of importing and using the library itself.
 module Database.Beam.AutoMigrate.Compat where
@@ -12,8 +14,6 @@ import Data.ByteString (ByteString)
 import Data.Int
 import qualified Data.Map.Strict as M
 import Data.Scientific (Scientific)
-import Data.Set (Set)
-import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Time (LocalTime, TimeOfDay, UTCTime)
@@ -23,7 +23,7 @@ import Data.UUID
 import Data.Word
 import qualified Database.Beam as Beam
 import Database.Beam.AutoMigrate.Types
-import qualified Database.Beam.AutoMigrate.Util as Util
+-- import qualified Database.Beam.AutoMigrate.Util as Util
 import Database.Beam.Backend.SQL hiding (tableName)
 import qualified Database.Beam.Backend.SQL.AST as AST
 import qualified Database.Beam.Postgres as Pg
@@ -44,17 +44,16 @@ class HasColumnType ty where
   defaultEnums :: Proxy ty -> Enumerations
   defaultEnums _ = mempty
 
-class Ord (SchemaConstraint ty) => HasSchemaConstraints ty where
+class HasSchemaConstraints ty where
   -- | Provide arbitrary constraints on a field of the requested type.
-  schemaConstraints :: Proxy ty -> Set (SchemaConstraint ty)
-  schemaConstraints _ = mempty
+  schemaConstraints :: Proxy ty -> SchemaConstraint ty
 
-class Ord (SchemaConstraint ty) => HasSchemaConstraints' (nullary :: Bool) ty where
-  schemaConstraints' :: Proxy nullary -> Proxy ty -> Set (SchemaConstraint ty)
+class HasSchemaConstraints' (nullary :: Bool) ty where
+  schemaConstraints' :: Proxy nullary -> Proxy ty -> SchemaConstraint ty
 
 type family SchemaConstraint (k :: *) where
-  SchemaConstraint (Beam.TableEntity e) = TableConstraint
-  SchemaConstraint (Beam.TableField e t) = ColumnConstraint
+  SchemaConstraint (Beam.TableEntity e) = TableConstraints
+  SchemaConstraint (Beam.TableField e t) = ColumnConstraints
 
 type family IsMaybe (k :: *) :: Bool where
   IsMaybe (Maybe x) = 'True
@@ -64,24 +63,24 @@ type family IsMaybe (k :: *) :: Bool where
 
 -- Default /table-level/ constraints.
 instance HasSchemaConstraints' 'True (Beam.TableEntity tbl) where
-  schemaConstraints' Proxy Proxy = mempty
+  schemaConstraints' Proxy Proxy = noTableConstraints
 
 instance HasSchemaConstraints' 'False (Beam.TableEntity tbl) where
-  schemaConstraints' Proxy Proxy = mempty
+  schemaConstraints' Proxy Proxy = noTableConstraints
 
 -- Default /field-level/ constraints.
 
 instance HasSchemaConstraints' 'True (Beam.TableField e (Beam.TableField e t)) where
-  schemaConstraints' Proxy Proxy = mempty
+  schemaConstraints' Proxy Proxy = noColumnConstraints
 
 instance HasSchemaConstraints' 'False (Beam.TableField e (Beam.TableField e t)) where
-  schemaConstraints' Proxy Proxy = S.singleton NotNull
+  schemaConstraints' Proxy Proxy = noColumnConstraints { columnNullable = NotNull }
 
 instance HasSchemaConstraints' 'True (Beam.TableField e (Maybe t)) where
-  schemaConstraints' Proxy Proxy = mempty
+  schemaConstraints' Proxy Proxy = noColumnConstraints
 
 instance HasSchemaConstraints' 'False (Beam.TableField e t) where
-  schemaConstraints' Proxy Proxy = S.singleton NotNull
+  schemaConstraints' Proxy Proxy = noColumnConstraints { columnNullable = NotNull }
 
 instance
   ( IsMaybe a ~ nullary,
@@ -105,14 +104,14 @@ class HasCompanionSequence' (generatesSeq :: Bool) ty where
     Proxy ty ->
     TableName ->
     ColumnName ->
-    Maybe ((SequenceName, Sequence), ColumnConstraint)
+    Maybe ((Maybe SequenceName, Sequence), DefaultConstraint)
 
 class HasCompanionSequence ty where
   hasCompanionSequence ::
     Proxy ty ->
     TableName ->
     ColumnName ->
-    Maybe ((SequenceName, Sequence), ColumnConstraint)
+    Maybe ((Maybe SequenceName, Sequence), DefaultConstraint)
 
 instance
   ( GeneratesSqlSequence ty ~ genSeq,
@@ -252,6 +251,7 @@ instance HasColumnType (Pg.PgRange Pg.PgDateRange a) where
 -- CREATE TABLE tablename (
 --     colname integer DEFAULT nextval('tablename_colname_seq') NOT NULL
 -- );
+-- ALTER SEQUENCE tablename_colname_seq OWNED BY tablename.colname;
 --
 -- Historically this was treated as a richer type (i.e. a 'PgSpecificType PgSerial') which had the advantage
 -- of being able, for example, to track down when a column type changed so that we were able to drop the
@@ -266,11 +266,8 @@ instance (Integral ty, HasColumnType ty) => HasColumnType (SqlSerial ty) where
 
 instance HasCompanionSequence' 'True (SqlSerial a) where
   hasCompanionSequence' Proxy Proxy tName cname =
-    let s@(SequenceName sname) = mkSeqName
-     in Just ((s, Sequence tName cname), Default ("nextval('" <> Util.sqlEscaped sname <> "'::regclass)"))
-    where
-      mkSeqName :: SequenceName
-      mkSeqName = SequenceName (tableName tName <> "___" <> columnName cname <> "___seq")
+    let s = Nothing
+     in Just ((s, Sequence tName cname), Autoincrement s)
 
 --
 -- support for enum types

--- a/src/Database/Beam/AutoMigrate/Diff.hs
+++ b/src/Database/Beam/AutoMigrate/Diff.hs
@@ -59,6 +59,7 @@ editPriority = \case
   ColumnAdded {} -> Priority 3
   ColumnDefaultChanged {} -> Priority 4
   ColumnNullableChanged {} -> Priority 4
+  SequenceRenamed {} -> Priority 4
   SequenceSetOwner {} -> Priority 5 -- set owner *after* creating the columns that should own it but before the default is created.
   -- Operations that set constraints or change the shape of a type have lower priority
   ColumnTypeChanged {} -> Priority 5
@@ -76,7 +77,6 @@ editPriority = \case
   EnumTypeRemoved {} -> Priority 15
   SequenceRemoved {} -> Priority 16
   RenameConstraint {} -> Priority 17 -- constraint manipulations are generated from the database
-  SequenceRenamed {} -> Priority 17
 
 -- TODO: This needs to support adding conditional queries.
 mkEdit :: AutomaticEditAction -> WithPriority Edit

--- a/src/Database/Beam/AutoMigrate/Diff.hs
+++ b/src/Database/Beam/AutoMigrate/Diff.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 
-{-# OPTIONS_GHC -Wall -Werror #-}
-
 module Database.Beam.AutoMigrate.Diff
   ( Diffable (..),
     Diff,
@@ -99,23 +97,14 @@ class Diffable a where
 -- or returning the list of 'Edit's necessary to turn the first into the second.
 instance Diffable Schema where
   diff hsSchema dbSchema = do
-    -- traceM "Diffable Schema"
     tableDiffs <- diff (schemaTables hsSchema) (schemaTables dbSchema)
-    -- traceM "Diffable Schema tableDiffs"
     enumDiffs <- diff (schemaEnumerations hsSchema) (schemaEnumerations dbSchema)
-    -- traceM "Diffable Schema tableDiffs enumDiffs"
 
     let hsSequences = diffableSequences hsSchema
-    -- traceM $ "Diffable Schema hsSequences: " <> show hsSequences
 
-    -- traceM $ "Diffable Schema dbSchema.schemaSequences: " <> show (schemaSequences dbSchema)
-    -- traceM $ "Diffable Schema dbSchema.schemaTables: " <> show (schemaTables dbSchema)
     let dbSequences = diffableSequences dbSchema
-    -- traceM $ "Diffable Schema dbSequences: " <> show dbSequences
 
     sequenceDiffs <- diff hsSequences dbSequences
-    -- traceM "Diffable Schema tableDiffs sequenceDiffs"
-    -- traceM "Diffable Schema OK"
     pure $ tableDiffs <> enumDiffs <> sequenceDiffs
 
 instance Diffable Tables where
@@ -126,8 +115,6 @@ instance Diffable Enumerations where
 
 instance Diffable DiffableSequences where
   diff s1 = fmap D.toList . diffSequences s1
-
-
 
 --
 -- Reference implementation
@@ -226,23 +213,23 @@ diffTablesReferenceImplementation hsTables dbTables = do
   pure $ whenAdded tablesAdded <> whenRemoved tablesRemoved <> whenBoth
   where
     whenAdded :: Tables -> [WithPriority Edit]
-    whenAdded = concatMap (addEdit' TableAdded (\k -> addTableConstraints k . tableConstraints)) . M.toList
+    whenAdded = concatMap (addEdit TableAdded (\k -> addTableConstraints k . tableConstraints)) . M.toList
 
     whenRemoved :: Tables -> [WithPriority Edit]
     whenRemoved =
-      concatMap (addEdit' (\k _ -> TableRemoved k) (\k -> dropTableConstraints k . tableConstraints)) . M.toList
+      concatMap (addEdit (\k _ -> TableRemoved k) (\k -> dropTableConstraints k . tableConstraints)) . M.toList
 
     go :: [WithPriority Edit] -> ((TableName, Table), (TableName, Table)) -> Diff
     go e ((hsName, hsTable), (dbName, dbTable)) = assert (hsName == dbName) $ do
       d <- diffTableReferenceImplementation hsName hsTable dbTable
       pure $ e <> d
 
-addEdit'
+addEdit
   :: (k -> v -> AutomaticEditAction)
   -> (k -> v -> [AutomaticEditAction])
   -> (k, v)
   -> [WithPriority Edit]
-addEdit' onValue onConstr (k, v) =
+addEdit onValue onConstr (k, v) =
   mkEdit (onValue k v) : fmap mkEdit (onConstr k v)
 
 diffTableReferenceImplementation :: TableName -> Table -> Table -> Diff
@@ -284,7 +271,7 @@ diffColumnReferenceImplementation tName colName hsColumn dbColumn = execWriterT 
     -- as a special case, filter out the places where we "learned" the sequence name.
     case on (,) (columnDefault . columnConstraints) hsColumn dbColumn of
       (Just (Autoincrement Nothing), Just (Autoincrement _)) -> pure ()
-      _ -> tell $ pure $ mkEdit $ ColumnDefaultChanged "diffColRI" tName colName $ columnDefault $ columnConstraints hsColumn
+      _ -> tell $ pure $ mkEdit $ ColumnDefaultChanged tName colName $ columnDefault $ columnConstraints hsColumn
 --
 -- Actual implementation
 --
@@ -364,7 +351,6 @@ diffSequences :: DiffableSequences -> DiffableSequences -> DiffA DList
 diffSequences
   (DiffableSequences hsSeqs hsCols _)
   (DiffableSequences dbSeqs dbCols dbColNames) = execWriterT $ do
-    -- traceM "diffSequences START"
     let -- organise the dbSeqs by their owner.
         dbSeqsInv = ifoldMap (\k v -> maybe M.empty (flip M.singleton k) v) dbSeqs
         (hsSeqs', hsCols') = ifor hsCols $ \s@(Sequence tName cName) sName ->
@@ -376,12 +362,11 @@ diffSequences
     -- we only keep the sequences we want to rename.
     renames <- mergeA
       (traverseMaybeMissing $ \(Sequence tName cName) sName -> do -- new autoincrement columns
-        -- traceM "diffSequences rename hsMissing"
-        forM_ sName $ tell . pure . mkEdit . ColumnDefaultChanged "diffSeq hscol" tName cName . Just . Autoincrement . Just
+        forM_ sName $ tell . pure . mkEdit . ColumnDefaultChanged tName cName . Just . Autoincrement . Just
         pure Nothing
         )
       (traverseMaybeMissing $ \(Sequence tName cName) sName -> do -- old autoincrement columns
-        forM_ sName $ \_ -> tell . pure . mkEdit $ ColumnDefaultChanged "diffSeq dbCol" tName cName Nothing
+        forM_ sName $ \_ -> tell . pure . mkEdit $ ColumnDefaultChanged tName cName Nothing
         pure Nothing
         )
       (zipWithMaybeAMatched $ \_ ->
@@ -401,7 +386,6 @@ diffSequences
           oldOwner <- at oldName <<.= Nothing
           at newName .= oldOwner
 
-    -- traceM "diffSequences renames"
     _ <- mergeA
       (traverseMaybeMissing $ \sName seqOwner -> do
         tell $ pure $ mkEdit $ SequenceAdded sName seqOwner
@@ -419,7 +403,6 @@ diffSequences
       (M.union hsSeqs hsSeqs')
       dbSeqs'
 
-    -- traceM "diffSequences OK"
     pure ()
 
 --

--- a/src/Database/Beam/AutoMigrate/Diff.hs
+++ b/src/Database/Beam/AutoMigrate/Diff.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 
+{-# OPTIONS_GHC -Wall -Werror #-}
+
 module Database.Beam.AutoMigrate.Diff
   ( Diffable (..),
     Diff,
@@ -21,15 +23,19 @@ module Database.Beam.AutoMigrate.Diff
   )
 where
 
+import Control.Monad.Writer.Strict
+import Control.Monad.State.Strict
+import Control.Applicative ((<|>))
+import Control.Lens (preview, _Nothing, ifoldMap, ifor, at, (.=), ix, (<<.=))
 import Control.Exception (assert)
-import Control.Monad
 import Data.DList (DList)
 import qualified Data.DList as D
-import Data.Foldable (foldlM)
-import Data.List (foldl', (\\))
+import Data.Foldable (foldlM, toList)
+import Data.List ((\\))
 import qualified Data.List as L
 import Data.Map.Merge.Strict
 import qualified Data.Map.Strict as M
+import Data.Function (on)
 import Data.Maybe
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -49,25 +55,28 @@ editPriority :: AutomaticEditAction -> Priority
 editPriority = \case
   -- Operations that create tables, sequences or enums have top priority
   EnumTypeAdded {} -> Priority 0
-  SequenceAdded {} -> Priority 1
-  TableAdded {} -> Priority 2
+  TableAdded {} -> Priority 1
+  SequenceAdded {} -> Priority 2
   -- We cannot create a column if the relevant table (or enum type) is not there.
   ColumnAdded {} -> Priority 3
+  ColumnDefaultChanged {} -> Priority 4
+  ColumnNullableChanged {} -> Priority 4
+  SequenceSetOwner {} -> Priority 5 -- set owner *after* creating the columns that should own it but before the default is created.
   -- Operations that set constraints or change the shape of a type have lower priority
-  ColumnTypeChanged {} -> Priority 4
-  EnumTypeValueAdded {} -> Priority 5
+  ColumnTypeChanged {} -> Priority 5
+  EnumTypeValueAdded {} -> Priority 6
   -- foreign keys need to go last, as the referenced columns needs to be either UNIQUE or have PKs.
-  TableConstraintAdded _ Unique {} -> Priority 6
-  TableConstraintAdded _ PrimaryKey {} -> Priority 7
-  TableConstraintAdded _ ForeignKey {} -> Priority 8
-  ColumnConstraintAdded {} -> Priority 9
-  TableConstraintRemoved {} -> Priority 10
-  ColumnConstraintRemoved {} -> Priority 11
+  UniqueConstraintAdded {} -> Priority 7
+  PrimaryKeyAdded {} -> Priority 8
+  ForeignKeyAdded {} -> Priority 9
+  TableConstraintRemoved {} -> Priority 11
   -- Destructive operations go last
-  ColumnRemoved {} -> Priority 12
-  TableRemoved {} -> Priority 13
-  EnumTypeRemoved {} -> Priority 14
-  SequenceRemoved {} -> Priority 15
+  ColumnRemoved {} -> Priority 13
+  TableRemoved {} -> Priority 14
+  EnumTypeRemoved {} -> Priority 15
+  SequenceRemoved {} -> Priority 16
+  RenameConstraint {} -> Priority 17 -- constraint manipulations are generated from the database
+  SequenceRenamed {} -> Priority 17
 
 -- TODO: This needs to support adding conditional queries.
 mkEdit :: AutomaticEditAction -> WithPriority Edit
@@ -90,9 +99,23 @@ class Diffable a where
 -- or returning the list of 'Edit's necessary to turn the first into the second.
 instance Diffable Schema where
   diff hsSchema dbSchema = do
+    -- traceM "Diffable Schema"
     tableDiffs <- diff (schemaTables hsSchema) (schemaTables dbSchema)
+    -- traceM "Diffable Schema tableDiffs"
     enumDiffs <- diff (schemaEnumerations hsSchema) (schemaEnumerations dbSchema)
-    sequenceDiffs <- diff (schemaSequences hsSchema) (schemaSequences dbSchema)
+    -- traceM "Diffable Schema tableDiffs enumDiffs"
+
+    let hsSequences = diffableSequences hsSchema
+    -- traceM $ "Diffable Schema hsSequences: " <> show hsSequences
+
+    -- traceM $ "Diffable Schema dbSchema.schemaSequences: " <> show (schemaSequences dbSchema)
+    -- traceM $ "Diffable Schema dbSchema.schemaTables: " <> show (schemaTables dbSchema)
+    let dbSequences = diffableSequences dbSchema
+    -- traceM $ "Diffable Schema dbSequences: " <> show dbSequences
+
+    sequenceDiffs <- diff hsSequences dbSequences
+    -- traceM "Diffable Schema tableDiffs sequenceDiffs"
+    -- traceM "Diffable Schema OK"
     pure $ tableDiffs <> enumDiffs <> sequenceDiffs
 
 instance Diffable Tables where
@@ -101,12 +124,92 @@ instance Diffable Tables where
 instance Diffable Enumerations where
   diff e1 = fmap D.toList . diffEnums e1
 
-instance Diffable Sequences where
+instance Diffable DiffableSequences where
   diff s1 = fmap D.toList . diffSequences s1
+
+
 
 --
 -- Reference implementation
 --
+
+-- | create all of the constraints in a TableConstraints
+addTableConstraints :: TableName -> TableConstraints -> [AutomaticEditAction]
+addTableConstraints tName hsConstraints = concat
+  [ toList $ fmap (uncurry $ PrimaryKeyAdded tName) (primaryKeyConstraint hsConstraints)
+  , fmap (uncurry $ UniqueConstraintAdded tName) (M.toList $ uniqueConstraints hsConstraints)
+  , fmap (uncurry $ ForeignKeyAdded tName) (M.toList $ foreignKeyConstraints hsConstraints)
+  ]
+
+-- | drop all of the constraints in a TableConstraints
+dropTableConstraints :: TableName -> TableConstraints -> [AutomaticEditAction]
+dropTableConstraints tName dbConstraints = concat
+  [ toList $ do
+    (_, co) <- primaryKeyConstraint dbConstraints --
+    cName <- uniqueConstraintName co
+    pure $ TableConstraintRemoved tName cName
+  , do
+    (_, co) <- M.toList $ uniqueConstraints dbConstraints
+    cName <- toList $ uniqueConstraintName co
+    pure $ TableConstraintRemoved tName cName
+  , do
+    (_, co) <- M.toList $ foreignKeyConstraints dbConstraints
+    cName <- toList $ foreignKeyConstraintName co
+    pure $ TableConstraintRemoved tName cName
+  ]
+
+-- | alter constraints on a table (including add/remove)
+alterTableConstraints :: TableName -> TableConstraints -> TableConstraints -> [AutomaticEditAction]
+alterTableConstraints tName hsConstraints dbConstraints =
+  let
+    tableConstraintsDifference l r = TableConstraints
+      { primaryKeyConstraint = preview _Nothing (primaryKeyConstraint r) *> primaryKeyConstraint l
+      , uniqueConstraints = M.difference (uniqueConstraints l) (uniqueConstraints r)
+      , foreignKeyConstraints = M.difference (foreignKeyConstraints l) (foreignKeyConstraints r)
+      }
+    newConstraints = tableConstraintsDifference hsConstraints dbConstraints
+    oldConstraints = tableConstraintsDifference dbConstraints hsConstraints
+  in addTableConstraints tName newConstraints
+    <> dropTableConstraints tName oldConstraints
+    <> (concat . toList) (liftM2 (alterUniqueConstraint tName)
+      (snd <$> primaryKeyConstraint hsConstraints)
+      (snd <$> primaryKeyConstraint dbConstraints))
+    <> (concat . toList) (M.intersectionWith (alterUniqueConstraint tName)
+      (uniqueConstraints hsConstraints)
+      (uniqueConstraints dbConstraints))
+    <> (concat . toList) (M.intersectionWithKey (alterForeignKeyConstraint tName)
+      (foreignKeyConstraints hsConstraints)
+      (foreignKeyConstraints dbConstraints))
+
+renameConstraint :: TableName -> Maybe ConstraintName -> Maybe ConstraintName -> Maybe AutomaticEditAction
+renameConstraint tName hsNames dbNames = do
+  hsName <- hsNames
+  dbName <- dbNames
+  guard (hsName /= dbName)
+  pure $ RenameConstraint tName dbName hsName
+
+
+alterUniqueConstraint :: TableName -> UniqueConstraintOptions -> UniqueConstraintOptions -> [AutomaticEditAction]
+alterUniqueConstraint tName hsOpts dbOpts = concat
+  [ toList $ renameConstraint tName (uniqueConstraintName hsOpts) (uniqueConstraintName dbOpts)
+  ]
+
+alterForeignKeyConstraint :: TableName -> ForeignKey -> ForeignKeyConstraintOptions -> ForeignKeyConstraintOptions -> [AutomaticEditAction]
+alterForeignKeyConstraint tName fkCon hsOpts dbOpts =
+  let
+    recreate = do
+      let mkAction f = guard (f hsOpts /= f dbOpts) *> pure (f dbOpts)
+          delAction = mkAction onDelete
+          updAction = mkAction onUpdate
+      _ <- delAction <|> updAction
+      -- TODO: this should error out instead of give up if the edit actions disagree but we don't know the constarint name
+      cName <- foreignKeyConstraintName hsOpts
+      pure
+        [ TableConstraintRemoved tName cName
+        , ForeignKeyAdded tName fkCon hsOpts
+        ]
+    rename = renameConstraint tName (foreignKeyConstraintName hsOpts) (foreignKeyConstraintName dbOpts)
+  in maybe [] id $ recreate <|> ((:[]) <$> rename)
 
 diffReferenceImplementation :: Schema -> Schema -> Diff
 diffReferenceImplementation hsSchema = diff (schemaTables hsSchema) . schemaTables
@@ -123,45 +226,36 @@ diffTablesReferenceImplementation hsTables dbTables = do
   pure $ whenAdded tablesAdded <> whenRemoved tablesRemoved <> whenBoth
   where
     whenAdded :: Tables -> [WithPriority Edit]
-    whenAdded = concatMap (addEdit TableAdded TableConstraintAdded tableConstraints) . M.toList
+    whenAdded = concatMap (addEdit' TableAdded (\k -> addTableConstraints k . tableConstraints)) . M.toList
 
     whenRemoved :: Tables -> [WithPriority Edit]
     whenRemoved =
-      concatMap (addEdit (\k _ -> TableRemoved k) TableConstraintRemoved tableConstraints) . M.toList
+      concatMap (addEdit' (\k _ -> TableRemoved k) (\k -> dropTableConstraints k . tableConstraints)) . M.toList
 
     go :: [WithPriority Edit] -> ((TableName, Table), (TableName, Table)) -> Diff
     go e ((hsName, hsTable), (dbName, dbTable)) = assert (hsName == dbName) $ do
       d <- diffTableReferenceImplementation hsName hsTable dbTable
       pure $ e <> d
 
-addEdit ::
-  (k -> v -> AutomaticEditAction) ->
-  (k -> c -> AutomaticEditAction) ->
-  (v -> S.Set c) ->
-  (k, v) ->
-  [WithPriority Edit]
-addEdit onValue onConstr getConstr (k, v) =
-  mkEdit (onValue k v) : map (mkEdit . onConstr k) (S.toList $ getConstr v)
+addEdit'
+  :: (k -> v -> AutomaticEditAction)
+  -> (k -> v -> [AutomaticEditAction])
+  -> (k, v)
+  -> [WithPriority Edit]
+addEdit' onValue onConstr (k, v) =
+  mkEdit (onValue k v) : fmap mkEdit (onConstr k v)
 
 diffTableReferenceImplementation :: TableName -> Table -> Table -> Diff
 diffTableReferenceImplementation tName hsTable dbTable = do
-  let constraintsAdded = S.difference (tableConstraints hsTable) (tableConstraints dbTable)
-      constraintsRemoved = S.difference (tableConstraints dbTable) (tableConstraints hsTable)
-      columnsAdded = M.difference (tableColumns hsTable) (tableColumns dbTable)
+  let columnsAdded = M.difference (tableColumns hsTable) (tableColumns dbTable)
       columnsRemoved = M.difference (tableColumns dbTable) (tableColumns hsTable)
       diffableColumns = M.intersection (tableColumns hsTable) (tableColumns dbTable)
       diffableColumns' = M.intersection (tableColumns dbTable) (tableColumns hsTable)
   whenBoth <- foldlM go mempty (zip (M.toList diffableColumns) (M.toList diffableColumns'))
-  let tblConstraintsAdded = do
-        guard (not $ S.null constraintsAdded)
-        pure $ map (mkEdit . TableConstraintAdded tName) (S.toList constraintsAdded)
-  let tblConstraintsRemoved = do
-        guard (not $ S.null constraintsRemoved)
-        pure $ map (mkEdit . TableConstraintRemoved tName) (S.toList constraintsRemoved)
   let colsAdded = whenAdded columnsAdded
-  let colsRemoved = whenRemoved columnsRemoved
-  pure $
-    join (catMaybes [tblConstraintsAdded, tblConstraintsRemoved])
+      colsRemoved = whenRemoved columnsRemoved
+      constraints = mkEdit <$> alterTableConstraints tName (tableConstraints hsTable) (tableConstraints dbTable)
+  pure $ constraints
       <> colsAdded
       <> colsRemoved
       <> whenBoth
@@ -172,28 +266,25 @@ diffTableReferenceImplementation tName hsTable dbTable = do
       pure $ e <> d
 
     whenAdded :: Columns -> [WithPriority Edit]
-    whenAdded =
-      concatMap (addEdit (ColumnAdded tName) (ColumnConstraintAdded tName) columnConstraints) . M.toList
+    whenAdded = fmap (\(cName, col) -> mkEdit $ ColumnAdded tName cName col) . M.toList
 
     whenRemoved :: Columns -> [WithPriority Edit]
-    whenRemoved =
-      concatMap (addEdit (\k _ -> ColumnRemoved tName k) (ColumnConstraintRemoved tName) columnConstraints) . M.toList
+    whenRemoved = fmap (mkEdit . ColumnRemoved tName) . M.keys
 
-diffColumnReferenceImplementation :: TableName -> ColumnName -> Column -> Column -> Diff
-diffColumnReferenceImplementation tName colName hsColumn dbColumn = do
-  let constraintsAdded = S.difference (columnConstraints hsColumn) (columnConstraints dbColumn)
-      constraintsRemoved = S.difference (columnConstraints dbColumn) (columnConstraints hsColumn)
-  let colConstraintsAdded = do
-        guard (not $ S.null constraintsAdded)
-        pure $ map (mkEdit . ColumnConstraintAdded tName colName) (S.toList constraintsAdded)
-  let colConstraintsRemoved = do
-        guard (not $ S.null constraintsRemoved)
-        pure $ map (mkEdit . ColumnConstraintRemoved tName colName) (S.toList constraintsRemoved)
-  let typeChanged = do
-        guard (columnType hsColumn /= columnType dbColumn)
-        pure [mkEdit $ ColumnTypeChanged tName colName (columnType dbColumn) (columnType hsColumn)]
-  pure $ join $ catMaybes [colConstraintsAdded, colConstraintsRemoved, typeChanged]
+diffColumnReferenceImplementation
+  :: (Applicative f, Monoid (f (WithPriority Edit))) => TableName -> ColumnName -> Column -> Column -> DiffA f
+diffColumnReferenceImplementation tName colName hsColumn dbColumn = execWriterT $ do
+  unless (on (==) columnType hsColumn dbColumn) $
+    tell $ pure $ mkEdit $ ColumnTypeChanged tName colName (columnType dbColumn) (columnType hsColumn)
 
+  unless (on (==) (columnNullable . columnConstraints) hsColumn dbColumn) $
+    tell $ pure $ mkEdit $ ColumnNullableChanged tName colName $ columnNullable $ columnConstraints hsColumn
+
+  unless (on (==) (columnDefault . columnConstraints) hsColumn dbColumn) $
+    -- as a special case, filter out the places where we "learned" the sequence name.
+    case on (,) (columnDefault . columnConstraints) hsColumn dbColumn of
+      (Just (Autoincrement Nothing), Just (Autoincrement _)) -> pure ()
+      _ -> tell $ pure $ mkEdit $ ColumnDefaultChanged "diffColRI" tName colName $ columnDefault $ columnConstraints hsColumn
 --
 -- Actual implementation
 --
@@ -238,24 +329,98 @@ appendAfter _ [] _ = mempty
 appendAfter eName [l] z = [mkEdit $ EnumTypeValueAdded eName l After z]
 appendAfter eName (l : ls) z = mkEdit (EnumTypeValueAdded eName l After z) : appendAfter eName ls l
 
---
--- Diffing sequences together
---
+data DiffableSequences = DiffableSequences
+  Sequences -- ^ explicitly named/optionally owned sequences.
+  (M.Map Sequence (Maybe SequenceName)) -- ^ autoincrement inferred column defaults
+  (M.Map TableName (S.Set ColumnName)) -- ^ all columns that happen to exist
+  deriving (Eq, Show)
 
-diffSequences :: Sequences -> Sequences -> DiffA DList
-diffSequences hsSeqs dbSeqs =
-  M.foldl' D.append mempty <$> mergeA whenSeqsAdded whenSeqsRemoved whenBoth hsSeqs dbSeqs
+diffableSequences :: Schema -> DiffableSequences
+diffableSequences = DiffableSequences
+  <$> schemaSequences
+  <*> ifoldMap (\tName -> ifoldMap (getAutoincrementColumns tName) . tableColumns) . schemaTables
+  <*> fmap (M.keysSet . tableColumns) . schemaTables
   where
-    whenSeqsAdded :: WhenMissing (Either DiffError) SequenceName Sequence (DList (WithPriority Edit))
-    whenSeqsAdded = traverseMissing (\k v -> Right . D.singleton . mkEdit $ SequenceAdded k v)
+    getAutoincrementColumns :: TableName -> ColumnName -> Column -> M.Map Sequence (Maybe SequenceName)
+    getAutoincrementColumns tName cName col = case columnDefault $ columnConstraints col of
+      Just (Autoincrement seqName') -> M.singleton (Sequence tName cName) seqName'
+      _ -> M.empty
 
-    whenSeqsRemoved :: WhenMissing (Either DiffError) SequenceName Sequence (DList (WithPriority Edit))
-    whenSeqsRemoved = traverseMissing (\k _ -> Right . D.singleton . mkEdit $ SequenceRemoved k)
+-- | Diffing sequences together
+--
+-- we need to work out two kinds of sequence:
+-- 1. sequences used as the default value on a column of some table (basically;
+-- the outcome of a column of type SERIAL or BIGSERIAL.  Sequences of this form
+-- don't normally have any particular name; although we need to know what it is
+-- eventually in order to actually build the diff.
+-- 2. sequences that aren't that.
+--
+-- It's really important that we don't drop and recreate sequences;  else the
+-- numbering may get reset.  The way this will work is that we'll look at eve
+-- as far migration goes, there's n things we need to manage:
+-- in hsSeqs, unowned sequences should or shouldn't exist.  we never guess names for those
+--
+diffSequences :: DiffableSequences -> DiffableSequences -> DiffA DList
+diffSequences
+  (DiffableSequences hsSeqs hsCols _)
+  (DiffableSequences dbSeqs dbCols dbColNames) = execWriterT $ do
+    -- traceM "diffSequences START"
+    let -- organise the dbSeqs by their owner.
+        dbSeqsInv = ifoldMap (\k v -> maybe M.empty (flip M.singleton k) v) dbSeqs
+        (hsSeqs', hsCols') = ifor hsCols $ \s@(Sequence tName cName) sName ->
+          let sName' = maybe (mkSequenceName tName cName) id $ sName <|> M.lookup s dbSeqsInv
+          in if (isJust $ preview (ix tName . ix cName) dbColNames)
+            then (M.singleton sName' $ Just s, Just sName')
+            else (M.empty, sName)
 
-    -- Currently a 'Sequence' doesn't carry any extra information, so diffing two 'Sequence's is
-    -- a no-op, basically.
-    whenBoth :: WhenMatched (Either DiffError) SequenceName Sequence Sequence (DList (WithPriority Edit))
-    whenBoth = zipWithAMatched (\_ (Sequence _ _) (Sequence _ _) -> Right mempty)
+    -- we only keep the sequences we want to rename.
+    renames <- mergeA
+      (traverseMaybeMissing $ \(Sequence tName cName) sName -> do -- new autoincrement columns
+        -- traceM "diffSequences rename hsMissing"
+        forM_ sName $ tell . pure . mkEdit . ColumnDefaultChanged "diffSeq hscol" tName cName . Just . Autoincrement . Just
+        pure Nothing
+        )
+      (traverseMaybeMissing $ \(Sequence tName cName) sName -> do -- old autoincrement columns
+        forM_ sName $ \_ -> tell . pure . mkEdit $ ColumnDefaultChanged "diffSeq dbCol" tName cName Nothing
+        pure Nothing
+        )
+      (zipWithMaybeAMatched $ \_ ->
+        let go hsSName dbSName
+              | hsSName == dbSName = pure Nothing
+              | otherwise = do
+                tell $ pure $ mkEdit $ SequenceRenamed dbSName hsSName
+                pure (Just (S.singleton (dbSName, hsSName)))
+        in \hsSName dbSName -> fmap join $ sequence $ liftM2 go hsSName dbSName)
+      hsCols'
+      dbCols
+
+    let renames' = foldMap id renames
+
+        -- the previous step handled the renames, update our db state to reflect that.
+        dbSeqs' = flip execState dbSeqs $ forM_ renames' $ \(oldName, newName) -> do
+          oldOwner <- at oldName <<.= Nothing
+          at newName .= oldOwner
+
+    -- traceM "diffSequences renames"
+    _ <- mergeA
+      (traverseMaybeMissing $ \sName seqOwner -> do
+        tell $ pure $ mkEdit $ SequenceAdded sName seqOwner
+        pure Nothing
+        ) -- sequence is new
+      (traverseMaybeMissing $ \sName _ -> do
+        tell $ pure $ mkEdit $ SequenceRemoved sName
+        pure Nothing
+      ) -- sequence is old
+      (zipWithMaybeAMatched $ \sName newOwner oldOwner -> do
+        unless (oldOwner == newOwner) $
+          tell $ pure $ mkEdit $ SequenceSetOwner sName newOwner
+        pure Nothing
+      ) -- sequence preserved
+      (M.union hsSeqs hsSeqs')
+      dbSeqs'
+
+    -- traceM "diffSequences OK"
+    pure ()
 
 --
 -- Diffing tables together
@@ -270,7 +435,7 @@ diffTables hsTables dbTables =
       traverseMissing
         ( \k v -> do
             let created = mkEdit $ TableAdded k v
-            let constraintsAdded = map (mkEdit . TableConstraintAdded k) (S.toList $ tableConstraints v)
+                constraintsAdded = mkEdit <$> addTableConstraints k (tableConstraints v)
             pure $ D.fromList (created : constraintsAdded)
         )
 
@@ -279,7 +444,7 @@ diffTables hsTables dbTables =
       traverseMissing
         ( \k v -> do
             let removed = mkEdit $ TableRemoved k
-            let constraintsRemoved = map (mkEdit . TableConstraintRemoved k) (S.toList $ tableConstraints v)
+                constraintsRemoved = mkEdit <$> dropTableConstraints k (tableConstraints v)
             pure $ D.fromList (removed : constraintsRemoved)
         )
 
@@ -288,51 +453,30 @@ diffTables hsTables dbTables =
 
 diffTable :: TableName -> Table -> Table -> DiffA DList
 diffTable tName hsTable dbTable = do
-  let constraintsAdded = S.difference (tableConstraints hsTable) (tableConstraints dbTable)
-      constraintsRemoved = S.difference (tableConstraints dbTable) (tableConstraints hsTable)
-      tblConstraintsAdded = do
-        guard (not $ S.null constraintsAdded)
-        pure $ D.map (mkEdit . TableConstraintAdded tName) (D.fromList . S.toList $ constraintsAdded)
-      tblConstraintsRemoved = do
-        guard (not $ S.null constraintsRemoved)
-        pure $ D.map (mkEdit . TableConstraintRemoved tName) (D.fromList . S.toList $ constraintsRemoved)
+  let tblConstraints = D.fromList $ fmap mkEdit $ alterTableConstraints tName (tableConstraints hsTable) (tableConstraints dbTable)
   diffs <-
     M.foldl' D.append mempty
       <$> mergeA whenColumnAdded whenColumnRemoved whenBoth (tableColumns hsTable) (tableColumns dbTable)
-  pure $ foldl' D.append D.empty (catMaybes [tblConstraintsAdded, tblConstraintsRemoved]) <> diffs
+  pure $ tblConstraints <> diffs
   where
     whenColumnAdded :: WhenMissing (Either DiffError) ColumnName Column (DList (WithPriority Edit))
     whenColumnAdded =
       traverseMissing
         ( \k v -> do
             let added = mkEdit $ ColumnAdded tName k v
-            let constraintsAdded = map (mkEdit . ColumnConstraintAdded tName k) (S.toList $ columnConstraints v)
-            pure $ D.fromList (added : constraintsAdded)
+            pure $ D.fromList (added : [])
         )
 
     whenColumnRemoved :: WhenMissing (Either DiffError) ColumnName Column (DList (WithPriority Edit))
     whenColumnRemoved =
       traverseMissing
-        ( \k v -> do
+        ( \k _ -> do
             let removed = mkEdit $ ColumnRemoved tName k
-            let constraintsRemoved = map (mkEdit . ColumnConstraintRemoved tName k) (S.toList $ columnConstraints v)
-            pure $ D.fromList (removed : constraintsRemoved)
+            pure $ D.fromList (removed : [])
         )
 
     whenBoth :: WhenMatched (Either DiffError) ColumnName Column Column (DList (WithPriority Edit))
     whenBoth = zipWithAMatched (diffColumn tName)
 
 diffColumn :: TableName -> ColumnName -> Column -> Column -> DiffA DList
-diffColumn tName colName hsColumn dbColumn = do
-  let constraintsAdded = S.difference (columnConstraints hsColumn) (columnConstraints dbColumn)
-      constraintsRemoved = S.difference (columnConstraints dbColumn) (columnConstraints hsColumn)
-  let colConstraintsAdded = do
-        guard (not $ S.null constraintsAdded)
-        pure $ D.map (mkEdit . ColumnConstraintAdded tName colName) (D.fromList . S.toList $ constraintsAdded)
-  let colConstraintsRemoved = do
-        guard (not $ S.null constraintsRemoved)
-        pure $ D.map (mkEdit . ColumnConstraintRemoved tName colName) (D.fromList . S.toList $ constraintsRemoved)
-  let typeChanged = do
-        guard (columnType hsColumn /= columnType dbColumn)
-        pure $ D.singleton (mkEdit $ ColumnTypeChanged tName colName (columnType dbColumn) (columnType hsColumn))
-  pure $ foldl' D.append D.empty $ catMaybes [colConstraintsAdded, colConstraintsRemoved, typeChanged]
+diffColumn = diffColumnReferenceImplementation

--- a/src/Database/Beam/AutoMigrate/Generic.hs
+++ b/src/Database/Beam/AutoMigrate/Generic.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# OPTIONS_GHC -Wall -Werror #-}
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Database.Beam.AutoMigrate.Generic where

--- a/src/Database/Beam/AutoMigrate/Parser.hs
+++ b/src/Database/Beam/AutoMigrate/Parser.hs
@@ -1,0 +1,55 @@
+
+{-# OPTIONS_GHC -Wall -Werror #-}
+-- | a fragment of a parser that can parse some of the sql that appears in postgres schema catalogs.
+--
+-- see "postgres/src/backend/parser/gram.y"
+--     "postgres/src/backend/parser/scan.l"
+-- for details.
+--
+module Database.Beam.AutoMigrate.Parser where
+
+
+import Control.Applicative
+import Data.Text (Text)
+import Data.Char (toLower)
+import qualified Data.Text as T
+import Database.Beam.AutoMigrate.Types
+import Data.Attoparsec.Text
+import Text.Parser.Token (token, parens)
+import qualified Text.Parser.Token as Parsers
+
+parseDefaultExpr :: Text -> DefaultConstraint
+parseDefaultExpr txt =
+  case parseOnly defaultExprSyntax txt of
+    Right ("nextval", (seqNm, "regclass")) ->
+      Autoincrement (Just (SequenceName seqNm))
+    _bad ->
+      DefaultExpr txt
+
+type DefaultExprSyntax = (SQL_IDENT, (SQL_STRING, SQL_IDENT))
+
+defaultExprSyntax :: Parser DefaultExprSyntax
+defaultExprSyntax = (,) <$> sqlIdent <*> parens ((,) <$> strQuotedIdent <* token "::" <*> sqlIdent)
+
+
+type SQL_IDENT = Text
+type SQL_STRING = Text
+
+sqlIdent :: Parser SQL_IDENT
+sqlIdent = token $
+  (T.pack <$> (char '"' *> many ('"' <$ "\"\"" <|> notChar '"') <* char '"'))
+  <|>
+  (T.pack . fmap toLower <$> liftA2 (:) (satisfy (inClass identStart)) (many $ satisfy (inClass identCont)))
+  where
+    identStart = "_A-Za-z"
+    identCont = identStart <> "0-9"
+
+sqlStrLiteral :: Parser SQL_STRING
+sqlStrLiteral = Parsers.stringLiteral'
+
+strQuotedIdent :: Parser SQL_IDENT
+strQuotedIdent = do
+  quotedIdent <- sqlStrLiteral
+  case parseOnly sqlIdent quotedIdent of
+    Right ok -> pure ok
+    Left bad -> fail $ "strQuotedIdent: " <> bad

--- a/src/Database/Beam/AutoMigrate/Parser.hs
+++ b/src/Database/Beam/AutoMigrate/Parser.hs
@@ -1,5 +1,3 @@
-
-{-# OPTIONS_GHC -Wall -Werror #-}
 -- | a fragment of a parser that can parse some of the sql that appears in postgres schema catalogs.
 --
 -- see "postgres/src/backend/parser/gram.y"

--- a/src/Database/Beam/AutoMigrate/Postgres.hs
+++ b/src/Database/Beam/AutoMigrate/Postgres.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE RankNTypes #-}
 
-
-{-# OPTIONS_GHC -Wall -Werror #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Database.Beam.AutoMigrate.Postgres

--- a/src/Database/Beam/AutoMigrate/Postgres.hs
+++ b/src/Database/Beam/AutoMigrate/Postgres.hs
@@ -302,8 +302,7 @@ getSchema conn = do
             M.lookup columnName x
 
       case asum
-        [ -- pgSerialTyColumnType atttypid mbDefault,
-          pgTypeToColumnType atttypid mbPrecision,
+        [ pgTypeToColumnType atttypid mbPrecision,
           pgEnumTypeToColumnType enumData atttypid
         ] of
         Just cType -> do
@@ -328,16 +327,6 @@ pgEnumTypeToColumnType ::
   Maybe ColumnType
 pgEnumTypeToColumnType enumData oid =
   (\(n, _) -> PgSpecificType (PgEnumeration n)) <$> M.lookup oid enumData
-
--- XXX: I don't understand how this comes to a different answer to pgTypeToColumnType
--- pgSerialTyColumnType ::
---   Pg.Oid ->
---   Maybe ColumnConstraint ->
---   Maybe ColumnType
--- pgSerialTyColumnType oid (Just (Default d)) = do
---   guard $ (Pg.typoid Pg.int4 == oid && "nextval" `T.isInfixOf` d && "seq" `T.isInfixOf` d)
---   pure $ SqlStdType intType
--- pgSerialTyColumnType _ _ = Nothing
 
 -- | Tries to convert from a Postgres' 'Oid' into 'ColumnType'.
 -- Mostly taken from [beam-migrate](Database.Beam.Postgres.Migrate).
@@ -537,8 +526,6 @@ mkAction c = case c of
 --
 -- Useful combinators to add constraints for a column or table if already there.
 --
-
-
 
 addFKConstraint :: TableName -> ForeignKey -> ForeignKeyConstraintOptions -> State AllTableConstraints ()
 addFKConstraint tName cns cnso = addTableConstraint tName $ noTableConstraints

--- a/src/Database/Beam/AutoMigrate/Postgres.hs
+++ b/src/Database/Beam/AutoMigrate/Postgres.hs
@@ -3,6 +3,11 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+
+
+{-# OPTIONS_GHC -Wall -Werror #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Database.Beam.AutoMigrate.Postgres
@@ -17,7 +22,6 @@ import Data.Foldable (asum, foldlM)
 import Data.Map (Map)
 import qualified Data.Map.Strict as M
 import Data.Maybe (fromMaybe)
-import Data.Set (Set)
 import qualified Data.Set as S
 import Data.String
 import Data.Text (Text)
@@ -33,6 +37,8 @@ import Database.PostgreSQL.Simple.FromRow (FromRow (..), field)
 import qualified Database.PostgreSQL.Simple.TypeInfo.Static as Pg
 import qualified Database.PostgreSQL.Simple.Types as Pg
 
+import Database.Beam.AutoMigrate.Parser (parseDefaultExpr)
+
 --
 -- Necessary types to make working with the underlying raw SQL a bit more pleasant
 --
@@ -43,7 +49,7 @@ data SqlRawOtherConstraintType
   deriving (Show, Eq)
 
 data SqlOtherConstraint = SqlOtherConstraint
-  { sqlCon_name :: Text,
+  { sqlCon_name :: ConstraintName,
     sqlCon_constraint_type :: SqlRawOtherConstraintType,
     sqlCon_table :: TableName,
     sqlCon_fk_colums :: V.Vector ColumnName
@@ -52,29 +58,34 @@ data SqlOtherConstraint = SqlOtherConstraint
 
 instance Pg.FromRow SqlOtherConstraint where
   fromRow =
-    SqlOtherConstraint <$> field
+    SqlOtherConstraint <$> fmap ConstraintName field
       <*> field
       <*> fmap TableName field
       <*> fmap (V.map ColumnName) field
 
 data SqlForeignConstraint = SqlForeignConstraint
-  { sqlFk_foreign_table :: TableName,
-    sqlFk_primary_table :: TableName,
-    -- | The columns in the /foreign/ table.
-    sqlFk_fk_columns :: V.Vector ColumnName,
-    -- | The columns in the /current/ table.
-    sqlFk_pk_columns :: V.Vector ColumnName,
-    sqlFk_name :: Text
+  { sqlFk_constraint_name :: ConstraintName,
+    sqlFk_self_schema :: Text,
+    -- | the table that has the foreign key constraint on it.
+    sqlFk_self_table :: TableName,
+    sqlFk_self_columns :: V.Vector ColumnName,
+    sqlFk_foreign_schema :: Text,
+    -- | the table mentioned after the REFERENCES kewyord in the foregn key constraintj
+    sqlFk_foreign_table :: TableName,
+    sqlFk_foreign_columns :: V.Vector ColumnName
   }
   deriving (Show, Eq)
 
 instance Pg.FromRow SqlForeignConstraint where
   fromRow =
-    SqlForeignConstraint <$> fmap TableName field
+    SqlForeignConstraint
+      <$> fmap ConstraintName field
+      <*> field
       <*> fmap TableName field
       <*> fmap (V.map ColumnName) field
-      <*> fmap (V.map ColumnName) field
       <*> field
+      <*> fmap TableName field
+      <*> fmap (V.map ColumnName) field
 
 instance FromField TableName where
   fromField f dat = TableName <$> fromField f dat
@@ -140,30 +151,55 @@ enumerationsQ =
 
 -- | Get the sequence data for all sequence types in the database.
 sequencesQ :: Pg.Query
-sequencesQ = fromString "SELECT c.relname FROM pg_class c WHERE c.relkind = 'S'"
+sequencesQ = fromString $ unlines
+  [ "SELECT"
+  , "  seqclass.relname,"
+  , "  subselect.table_name,"
+  , "  subselect.column_name"
+  , "FROM pg_class AS seqclass"
+  , "LEFT OUTER JOIN ("
+  , "  SELECT"
+  , "    depclass.relname AS table_name,"
+  , "    attrib.attname   AS column_name,"
+  , "    dep.objid AS dep_objid"
+  , "  FROM pg_depend AS dep"
+  , "  JOIN pg_class AS depclass"
+  , "    ON ( dep.refobjid = depclass.relfilenode )"
+  , "  JOIN pg_attribute AS attrib"
+  , "    ON ( attrib.attnum = dep.refobjsubid"
+  , "    AND attrib.attrelid = dep.refobjid )"
+  , "  ) AS subselect"
+  , "  ON ( seqclass.relfilenode = subselect.dep_objid )"
+  , "WHERE  seqclass.relkind = 'S'"
+  ]
+
 
 -- | Return all foreign key constraints for /all/ 'Table's.
+-- SEE: https://dba.stackexchange.com/a/218969
 foreignKeysQ :: Pg.Query
 foreignKeysQ =
   fromString $
     unlines
-      [ "SELECT kcu.table_name::text as foreign_table,",
-        "       rel_kcu.table_name::text as primary_table,",
-        "       array_agg(kcu.column_name::text ORDER BY kcu.position_in_unique_constraint)::text[] as fk_columns,",
-        "       array_agg(rel_kcu.column_name::text ORDER BY rel_kcu.ordinal_position)::text[] as pk_columns,",
-        "       kcu.constraint_name as cname",
-        "FROM information_schema.table_constraints tco",
-        "JOIN information_schema.key_column_usage kcu",
-        "          on tco.constraint_schema = kcu.constraint_schema",
-        "          and tco.constraint_name = kcu.constraint_name",
-        "JOIN information_schema.referential_constraints rco",
-        "          on tco.constraint_schema = rco.constraint_schema",
-        "          and tco.constraint_name = rco.constraint_name",
-        "JOIN information_schema.key_column_usage rel_kcu",
-        "          on rco.unique_constraint_schema = rel_kcu.constraint_schema",
-        "          and rco.unique_constraint_name = rel_kcu.constraint_name",
-        "          and kcu.ordinal_position = rel_kcu.ordinal_position",
-        "GROUP BY foreign_table, primary_table, cname"
+      [ "SELECT c.conname                                 AS constraint_name,",
+        -- "   c.contype                                     AS constraint_type,",
+        "   sch.nspname                                   AS self_schema,",
+        "   tbl.relname                                   AS self_table,",
+        "   ARRAY_AGG(col.attname ORDER BY u.attposition) AS self_columns,",
+        "   f_sch.nspname                                 AS foreign_schema,",
+        "   f_tbl.relname                                 AS foreign_table,",
+        "   ARRAY_AGG(f_col.attname ORDER BY f_u.attposition) AS foreign_columns",
+        "FROM pg_constraint c",
+        "       LEFT JOIN LATERAL UNNEST(c.conkey) WITH ORDINALITY AS u(attnum, attposition) ON TRUE",
+        "       LEFT JOIN LATERAL UNNEST(c.confkey) WITH ORDINALITY AS f_u(attnum, attposition) ON f_u.attposition = u.attposition",
+        "       JOIN pg_class tbl ON tbl.oid = c.conrelid",
+        "       JOIN pg_namespace sch ON sch.oid = tbl.relnamespace",
+        "       LEFT JOIN pg_attribute col ON (col.attrelid = tbl.oid AND col.attnum = u.attnum)",
+        "       LEFT JOIN pg_class f_tbl ON f_tbl.oid = c.confrelid",
+        "       LEFT JOIN pg_namespace f_sch ON f_sch.oid = f_tbl.relnamespace",
+        "       LEFT JOIN pg_attribute f_col ON (f_col.attrelid = f_tbl.oid AND f_col.attnum = f_u.attnum)",
+        "WHERE c.contype = 'f'",
+        "GROUP BY constraint_name, c.contype, self_schema, self_table, foreign_schema, foreign_table",
+        "ORDER BY self_schema, self_table"
       ]
 
 -- | Return /all other constraints that are not FKs/ (i.e. 'PRIMARY KEY', 'UNIQUE', etc) for all the tables.
@@ -222,13 +258,11 @@ getSchema conn = do
 
     getSequence ::
       Sequences ->
-      Pg.Only Text ->
+      (Text, Maybe Text, Maybe Text) ->
       IO Sequences
-    getSequence allSeqs (Pg.Only seqName) =
-      case T.splitOn "___" seqName of
-        [tName, cName, "seq"] ->
-          pure $ M.insert (SequenceName seqName) (Sequence (TableName tName) (ColumnName cName)) allSeqs
-        _ -> pure allSeqs
+    getSequence allSeqs (seqName, tNames, cNames) = do
+      let seqOwner = Sequence <$> fmap TableName tNames <*> fmap ColumnName cNames
+      pure $ M.insert (SequenceName seqName) seqOwner allSeqs
 
     getTable ::
       AllDefaults ->
@@ -270,14 +304,13 @@ getSchema conn = do
             M.lookup columnName x
 
       case asum
-        [ pgSerialTyColumnType atttypid mbDefault,
+        [ -- pgSerialTyColumnType atttypid mbDefault,
           pgTypeToColumnType atttypid mbPrecision,
           pgEnumTypeToColumnType enumData atttypid
         ] of
         Just cType -> do
-          let nullConstraint = if attnotnull then S.fromList [NotNull] else mempty
-          let inferredConstraints = nullConstraint <> fromMaybe mempty (S.singleton <$> mbDefault)
-          let newColumn = Column cType inferredConstraints
+          let nullConstraint = if attnotnull then NotNull else Null
+          let newColumn = Column cType $ ColumnConstraints nullConstraint mbDefault
           pure $ M.insert columnName newColumn c
         Nothing ->
           fail $
@@ -298,14 +331,15 @@ pgEnumTypeToColumnType ::
 pgEnumTypeToColumnType enumData oid =
   (\(n, _) -> PgSpecificType (PgEnumeration n)) <$> M.lookup oid enumData
 
-pgSerialTyColumnType ::
-  Pg.Oid ->
-  Maybe ColumnConstraint ->
-  Maybe ColumnType
-pgSerialTyColumnType oid (Just (Default d)) = do
-  guard $ (Pg.typoid Pg.int4 == oid && "nextval" `T.isInfixOf` d && "seq" `T.isInfixOf` d)
-  pure $ SqlStdType intType
-pgSerialTyColumnType _ _ = Nothing
+-- XXX: I don't understand how this comes to a different answer to pgTypeToColumnType
+-- pgSerialTyColumnType ::
+--   Pg.Oid ->
+--   Maybe ColumnConstraint ->
+--   Maybe ColumnType
+-- pgSerialTyColumnType oid (Just (Default d)) = do
+--   guard $ (Pg.typoid Pg.int4 == oid && "nextval" `T.isInfixOf` d && "seq" `T.isInfixOf` d)
+--   pure $ SqlStdType intType
+-- pgSerialTyColumnType _ _ = Nothing
 
 -- | Tries to convert from a Postgres' 'Oid' into 'ColumnType'.
 -- Mostly taken from [beam-migrate](Database.Beam.Postgres.Migrate).
@@ -382,11 +416,11 @@ pgTypeToColumnType oid width
 -- Constraints discovery
 --
 
-type AllTableConstraints = Map TableName (Set TableConstraint)
+type AllTableConstraints = Map TableName TableConstraints
 
 type AllDefaults = Map TableName Defaults
 
-type Defaults = Map ColumnName ColumnConstraint
+type Defaults = Map ColumnName DefaultConstraint
 
 -- Get all defaults values for /all/ the columns.
 -- FIXME(adn) __IMPORTANT:__ This function currently __always_ attach an explicit type annotation to the
@@ -429,13 +463,9 @@ getAllDefaults :: Pg.Connection -> IO AllDefaults
 getAllDefaults conn = Pg.fold_ conn defaultsQ mempty (\acc -> pure . addDefault acc)
   where
     addDefault :: AllDefaults -> (TableName, ColumnName, Text, Text) -> AllDefaults
-    addDefault m (tName, colName, defValue, dataType) =
-      let cleanedDefault = case T.breakOn "::" defValue of
-            (uncasted, defMb)
-              | T.null defMb ->
-                "'" <> T.dropAround ((==) '\'') uncasted <> "'::" <> dataType
-            _ -> defValue
-          entry = M.singleton colName (Default cleanedDefault)
+    addDefault m (tName, colName, defValue, _dataType) =
+      let cleanedDefault = parseDefaultExpr defValue
+          entry = M.singleton colName cleanedDefault
        in M.alter
             ( \case
                 Nothing -> Just entry
@@ -456,13 +486,14 @@ getAllConstraints conn = do
       SqlForeignConstraint ->
       AllTableConstraints
     addFkConstraint actions st SqlForeignConstraint {..} = flip execState st $ do
-      let currentTable = sqlFk_foreign_table
-      let columnSet = S.fromList $ zip (V.toList sqlFk_fk_columns) (V.toList sqlFk_pk_columns)
+      let columnSet = S.fromList $ zip (V.toList sqlFk_self_columns) (V.toList sqlFk_foreign_columns)
       let (onDelete, onUpdate) =
-            case M.lookup sqlFk_name (getActions actions) of
+            case M.lookup sqlFk_constraint_name (getActions actions) of
               Nothing -> (NoAction, NoAction)
               Just a -> (actionOnDelete a, actionOnUpdate a)
-      addTableConstraint currentTable (ForeignKey sqlFk_name sqlFk_primary_table columnSet onDelete onUpdate)
+      addFKConstraint (sqlFk_self_table)
+        (ForeignKey sqlFk_foreign_table columnSet)
+        (ForeignKeyConstraintOptions (Just sqlFk_constraint_name) onDelete onUpdate)
 
     addOtherConstraint ::
       AllTableConstraints ->
@@ -472,13 +503,12 @@ getAllConstraints conn = do
       let currentTable = sqlCon_table
       let columnSet = S.fromList . V.toList $ sqlCon_fk_colums
       case sqlCon_constraint_type of
-        SQL_raw_unique -> addTableConstraint currentTable (Unique sqlCon_name columnSet)
-        SQL_raw_pk -> if S.null columnSet then pure () else
-          addTableConstraint currentTable (PrimaryKey sqlCon_name columnSet)
+        SQL_raw_unique -> addUniqConstraint currentTable (Unique columnSet) (UniqueConstraintOptions (Just sqlCon_name))
+        SQL_raw_pk -> addPKConstraint currentTable (PrimaryKey columnSet) (UniqueConstraintOptions (Just sqlCon_name))
 
-newtype ReferenceActions = ReferenceActions {getActions :: Map Text Actions}
+newtype ReferenceActions = ReferenceActions {getActions :: Map ConstraintName Actions}
 
-newtype RefEntry = RefEntry {unRefEntry :: (Text, ReferenceAction, ReferenceAction)}
+newtype RefEntry = RefEntry {unRefEntry :: (ConstraintName, ReferenceAction, ReferenceAction)}
 
 mkActions :: [RefEntry] -> ReferenceActions
 mkActions = ReferenceActions . M.fromList . map ((\(a, b, c) -> (a, Actions b c)) . unRefEntry)
@@ -487,7 +517,7 @@ instance Pg.FromRow RefEntry where
   fromRow =
     fmap
       RefEntry
-      ( (,,) <$> field
+      ( (,,) <$> fmap ConstraintName field
           <*> fmap mkAction field
           <*> fmap mkAction field
       )
@@ -510,16 +540,22 @@ mkAction c = case c of
 -- Useful combinators to add constraints for a column or table if already there.
 --
 
+
+
+addFKConstraint :: TableName -> ForeignKey -> ForeignKeyConstraintOptions -> State AllTableConstraints ()
+addFKConstraint tName cns cnso = addTableConstraint tName $ noTableConstraints
+  { foreignKeyConstraints = M.singleton cns cnso }
+
+addUniqConstraint :: TableName -> Unique -> UniqueConstraintOptions -> State AllTableConstraints ()
+addUniqConstraint tName cns cnso = addTableConstraint tName $ noTableConstraints
+  { uniqueConstraints = M.singleton cns cnso }
+
+addPKConstraint :: TableName -> PrimaryKeyConstraint -> UniqueConstraintOptions -> State AllTableConstraints ()
+addPKConstraint tName cns cnso = addTableConstraint tName $ noTableConstraints
+  { primaryKeyConstraint = Just (cns, cnso) }
+
 addTableConstraint ::
   TableName ->
-  TableConstraint ->
+  TableConstraints ->
   State AllTableConstraints ()
-addTableConstraint tName cns =
-  modify'
-    ( M.alter
-        ( \case
-            Nothing -> Just $ S.singleton cns
-            Just ss -> Just $ S.insert cns ss
-        )
-        tName
-    )
+addTableConstraint tName cns = modify' $ M.unionWith (<>) (M.singleton tName cns)

--- a/src/Database/Beam/AutoMigrate/Schema/Gen.hs
+++ b/src/Database/Beam/AutoMigrate/Schema/Gen.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE ViewPatterns #-}
 
-{-# OPTIONS_GHC -Wall -Werror #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Database.Beam.AutoMigrate.Schema.Gen

--- a/src/Database/Beam/AutoMigrate/Types.hs
+++ b/src/Database/Beam/AutoMigrate/Types.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-{-# OPTIONS_GHC -Wall -Werror #-}
-
 module Database.Beam.AutoMigrate.Types where
 
 import Control.DeepSeq
@@ -273,13 +271,6 @@ data DefaultConstraint
 
 instance NFData DefaultConstraint
 
--- data ColumnConstraint
---   = NotNull
---   | Default DefaultConstraint {- the actual default -}
---   deriving (Show, Eq, Ord, Generic)
---
--- instance NFData ColumnConstraint
-
 data ReferenceAction
   = NoAction
   | Restrict
@@ -322,7 +313,7 @@ data AutomaticEditAction
   | ColumnRemoved TableName ColumnName
   | ColumnTypeChanged TableName ColumnName ColumnType {- old type -} ColumnType {- new type -}
   | ColumnNullableChanged TableName ColumnName NullableConstraint {- is nullable -}
-  | ColumnDefaultChanged String TableName ColumnName (Maybe DefaultConstraint)
+  | ColumnDefaultChanged TableName ColumnName (Maybe DefaultConstraint)
   | EnumTypeAdded EnumerationName Enumeration
   | EnumTypeRemoved EnumerationName
   | EnumTypeValueAdded EnumerationName Text {- added value -} InsertionOrder Text {- insertion point -}
@@ -436,7 +427,7 @@ instance NFData AutomaticEditAction where
   rnf (ColumnRemoved tName colName) = tName `deepseq` colName `deepseq` ()
   rnf (ColumnTypeChanged tName colName c1 c2) = c1 `seq` c2 `seq` tName `deepseq` colName `deepseq` ()
   rnf (ColumnNullableChanged tName cName cCon) = tName `deepseq` cName `deepseq` cCon `deepseq` ()
-  rnf (ColumnDefaultChanged _ tName colName cCon) = tName `deepseq` colName `deepseq` cCon `deepseq` ()
+  rnf (ColumnDefaultChanged tName colName cCon) = tName `deepseq` colName `deepseq` cCon `deepseq` ()
   rnf (EnumTypeAdded eName enum) = eName `deepseq` enum `deepseq` ()
   rnf (EnumTypeRemoved eName) = eName `deepseq` ()
   rnf (EnumTypeValueAdded eName inserted order insertionPoint) =

--- a/src/Database/Beam/AutoMigrate/Types.hs
+++ b/src/Database/Beam/AutoMigrate/Types.hs
@@ -4,12 +4,17 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -Wall -Werror #-}
 
 module Database.Beam.AutoMigrate.Types where
 
 import Control.DeepSeq
+import Control.Applicative
 import Control.Exception
 import Data.ByteString.Lazy (ByteString)
+import Data.Default.Class (Default(..))
 import Data.Map (Map)
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
@@ -17,14 +22,17 @@ import Data.String
 import Data.String.Conv (toS)
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Map as Map
 import Data.Typeable
 import Database.Beam.Backend.SQL (BeamSqlBackendSyntax)
 import qualified Database.Beam.Backend.SQL.AST as AST
 import Database.Beam.Postgres (Pg, Postgres)
 import qualified Database.Beam.Postgres.Syntax as Syntax
 import GHC.Generics hiding (to)
-import Lens.Micro (Lens', lens, to, _Right)
-import Lens.Micro.Extras (preview)
+import Control.Lens (Lens', lens, to, _Right)
+import Control.Lens (preview, set)
+
+import Control.Lens.TH
 
 --
 -- Types (sketched)
@@ -63,7 +71,7 @@ instance NFData Enumeration
 -- Sequences
 --
 
-type Sequences = Map SequenceName Sequence
+type Sequences = Map SequenceName (Maybe Sequence)
 
 newtype SequenceName = SequenceName
   { seqName :: Text
@@ -85,11 +93,6 @@ instance NFData Sequence
 mkSequenceName :: TableName -> ColumnName -> SequenceName
 mkSequenceName tname cname = SequenceName (tableName tname <> "___" <> columnName cname <> "___seq")
 
-parseSequenceName :: SequenceName -> Maybe (TableName, ColumnName)
-parseSequenceName (SequenceName sName) = case T.splitOn "___" sName of
-  [tName, cName, "seq"] -> Just (TableName tName, ColumnName cName)
-  _ -> Nothing
-
 --
 -- Tables
 --
@@ -104,8 +107,22 @@ newtype TableName = TableName
 instance IsString TableName where
   fromString = TableName . T.pack
 
+data TableConstraints = TableConstraints
+  { primaryKeyConstraint :: Maybe (PrimaryKeyConstraint, UniqueConstraintOptions)
+  , foreignKeyConstraints :: Map ForeignKey ForeignKeyConstraintOptions
+  , uniqueConstraints :: Map Unique UniqueConstraintOptions
+  } deriving (Eq, Show, Generic)
+
+instance Semigroup TableConstraints where
+  TableConstraints pk1 fk1 u1 <> TableConstraints pk2 fk2 u2 = TableConstraints
+    (pk1 <> pk2)
+    (Map.unionWith (<>) fk1 fk2)
+    (Map.unionWith (<>) u1 u2)
+
+instance NFData TableConstraints
+
 data Table = Table
-  { tableConstraints :: Set TableConstraint,
+  { tableConstraints :: TableConstraints,
     tableColumns :: Columns
   }
   deriving (Eq, Show, Generic)
@@ -122,15 +139,27 @@ newtype ColumnName = ColumnName
 instance IsString ColumnName where
   fromString = ColumnName . T.pack
 
+data NullableConstraint = Null | NotNull
+  deriving (Show, Eq, Generic)
+
+instance NFData NullableConstraint
+
+data ColumnConstraints = ColumnConstraints
+  { columnNullable :: NullableConstraint,
+    columnDefault :: Maybe DefaultConstraint
+  } deriving (Show, Eq, Generic)
+
+instance NFData ColumnConstraints
+
 data Column = Column
   { columnType :: ColumnType,
-    columnConstraints :: Set ColumnConstraint
+    columnConstraints :: ColumnConstraints
   }
   deriving (Show, Eq, Generic)
 
 -- Manual instance as 'AST.DataType' doesn't derive 'NFData'.
 instance NFData Column where
-  rnf c = rnf (columnConstraints c)
+  rnf c = columnConstraints c `deepseq` ()
 
 -- | Basic types for columns. We piggyback on 'beam-core' SQL types for now. Albeit they are a bit more
 -- specialised (i.e, SQL specific), we are less subject from their and our representation to diverge.
@@ -172,32 +201,84 @@ newtype DbEnum a
   = DbEnum a
   deriving (Show, Eq, Typeable, Enum, Bounded, Generic)
 
-instance Semigroup Table where
-  (Table c1 t1) <> (Table c2 t2) = Table (c1 <> c2) (t1 <> t2)
+newtype ConstraintName = ConstraintName { unConsraintName :: Text }
+  deriving (IsString, Eq, Ord, Show, NFData)
 
-instance Monoid Table where
-  mempty = Table mempty mempty
+data PrimaryKeyConstraint = PrimaryKey
+      -- | This set of 'Column's identifies the Table's 'PrimaryKey'.
+      (Set ColumnName)
+  deriving (Eq, Ord, Show, Generic)
 
-type ConstraintName = Text
 
-data TableConstraint
-  = -- | This set of 'Column's identifies the Table's 'PrimaryKey'.
-    PrimaryKey ConstraintName (Set ColumnName)
-  | -- | This set of 'Column's identifies a Table's 'ForeignKey'. This is usually found in the 'tableConstraints'
+instance Semigroup PrimaryKeyConstraint where
+  PrimaryKey c1 <> PrimaryKey c2 = PrimaryKey (c1 <> c2)
+
+instance NFData PrimaryKeyConstraint
+
+  -- | This set of 'Column's identifies a Table's 'ForeignKey'. This is usually found in the 'tableConstraints'
     -- of the table where the foreign key is actually defined (in terms of 'REFERENCES').
     -- The set stores a (fk_column, pk_column) correspondence.
-    ForeignKey ConstraintName TableName (Set (ColumnName, ColumnName)) ReferenceAction {- onDelete -} ReferenceAction {- onUpdate -}
-  | Unique ConstraintName (Set ColumnName)
+data ForeignKey = ForeignKey
+  TableName
+  (Set (ColumnName, ColumnName))
+  deriving (Eq, Ord, Show, Generic)
+
+instance NFData ForeignKey
+
+data ForeignKeyConstraintOptions = ForeignKeyConstraintOptions
+  { foreignKeyConstraintName :: Maybe ConstraintName -- ^ The Maybe indicates not that the constraint might not have a name, but that we aren't obligated it to name it immediately.
+  , onDelete :: ReferenceAction {- onDelete -}
+  , onUpdate :: ReferenceAction {- onUpdate -}
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+instance Default ForeignKeyConstraintOptions where
+  def = ForeignKeyConstraintOptions Nothing NoAction NoAction
+
+instance Semigroup ForeignKeyConstraintOptions where
+  ForeignKeyConstraintOptions n1 d1 u1 <> ForeignKeyConstraintOptions n2 d2 u2 = ForeignKeyConstraintOptions
+    (n1 <|> n2)
+    (const d1 d2)
+    (const u1 u2)
+
+instance NFData ForeignKeyConstraintOptions
+
+data Unique = Unique (Set ColumnName)
   deriving (Show, Eq, Ord, Generic)
 
-instance NFData TableConstraint
+instance NFData Unique
 
-data ColumnConstraint
-  = NotNull
-  | Default Text {- the actual default -}
+data UniqueConstraintOptions = UniqueConstraintOptions
+  { uniqueConstraintName :: Maybe ConstraintName -- ^ The Maybe indicates not that the constraint might not have a name, but that we aren't obligated it to name it immediately.
+  }
+  deriving (Eq, Ord, Show, Generic)
+
+-- | suitable default options which allows postgres to choose a constraint name
+instance Default UniqueConstraintOptions where
+  def = UniqueConstraintOptions Nothing
+
+instance Semigroup UniqueConstraintOptions where
+  UniqueConstraintOptions n1 <> UniqueConstraintOptions n2 = UniqueConstraintOptions
+    (n1 <|> n2)
+
+instance NFData UniqueConstraintOptions
+
+-- | we will treat default constraint expressions specially in the case that a column is associated with a sequence.
+--
+-- We only ever represent two kinds of sequence, either the sequence is owned by a column which has a default of nextval(sequence); or else the sequence is not owned, and must have a name.
+data DefaultConstraint
+  = DefaultExpr Text
+  | Autoincrement (Maybe SequenceName)
   deriving (Show, Eq, Ord, Generic)
 
-instance NFData ColumnConstraint
+instance NFData DefaultConstraint
+
+-- data ColumnConstraint
+--   = NotNull
+--   | Default DefaultConstraint {- the actual default -}
+--   deriving (Show, Eq, Ord, Generic)
+--
+-- instance NFData ColumnConstraint
 
 data ReferenceAction
   = NoAction
@@ -226,18 +307,31 @@ data ManualEditAction
 data AutomaticEditAction
   = TableAdded TableName Table
   | TableRemoved TableName
-  | TableConstraintAdded TableName TableConstraint
-  | TableConstraintRemoved TableName TableConstraint
+
+
+  | PrimaryKeyAdded TableName PrimaryKeyConstraint UniqueConstraintOptions
+  | UniqueConstraintAdded TableName Unique UniqueConstraintOptions
+  | ForeignKeyAdded TableName ForeignKey ForeignKeyConstraintOptions
+
+  | TableConstraintRemoved TableName ConstraintName
+  | RenameConstraint TableName
+    ConstraintName {- old name -}
+    ConstraintName {- new name -}
+
   | ColumnAdded TableName ColumnName Column
   | ColumnRemoved TableName ColumnName
   | ColumnTypeChanged TableName ColumnName ColumnType {- old type -} ColumnType {- new type -}
-  | ColumnConstraintAdded TableName ColumnName ColumnConstraint
-  | ColumnConstraintRemoved TableName ColumnName ColumnConstraint
+  | ColumnNullableChanged TableName ColumnName NullableConstraint {- is nullable -}
+  | ColumnDefaultChanged String TableName ColumnName (Maybe DefaultConstraint)
   | EnumTypeAdded EnumerationName Enumeration
   | EnumTypeRemoved EnumerationName
   | EnumTypeValueAdded EnumerationName Text {- added value -} InsertionOrder Text {- insertion point -}
-  | SequenceAdded SequenceName Sequence
+  | SequenceAdded SequenceName (Maybe Sequence)
   | SequenceRemoved SequenceName
+  | SequenceRenamed
+    SequenceName {- old name -}
+    SequenceName {- new name -}
+  | SequenceSetOwner SequenceName (Maybe Sequence)
   deriving (Show, Eq)
 
 -- | Safety rating for a given edit.
@@ -251,15 +345,20 @@ data EditSafety
 
 defaultEditSafety :: AutomaticEditAction -> EditSafety
 defaultEditSafety = \case
+  SequenceRenamed {} -> Safe
+  SequenceSetOwner {} -> Safe
   TableAdded {} -> Safe
   TableRemoved {} -> Unsafe
-  TableConstraintAdded {} -> Safe
+  PrimaryKeyAdded {} -> Safe
+  ForeignKeyAdded {} -> Safe
+  UniqueConstraintAdded {} -> Safe
   TableConstraintRemoved {} -> Safe
+  RenameConstraint {} -> Safe
   ColumnAdded {} -> Safe
   ColumnRemoved {} -> Unsafe
   ColumnTypeChanged {} -> Unsafe
-  ColumnConstraintAdded {} -> Safe
-  ColumnConstraintRemoved {} -> Safe
+  ColumnNullableChanged {} -> Safe
+  ColumnDefaultChanged {} -> Safe
   EnumTypeAdded {} -> Safe
   EnumTypeRemoved {} -> Unsafe
   EnumTypeValueAdded {} -> Safe
@@ -330,19 +429,24 @@ instance NFData ManualEditAction where
 instance NFData AutomaticEditAction where
   rnf (TableAdded tName tbl) = tName `deepseq` tbl `deepseq` ()
   rnf (TableRemoved tName) = rnf tName
-  rnf (TableConstraintAdded tName tCon) = tName `deepseq` tCon `deepseq` ()
-  rnf (TableConstraintRemoved tName tCon) = tName `deepseq` tCon `deepseq` ()
+  rnf (UniqueConstraintAdded tName tCon tOpts) = tName `deepseq` tCon `deepseq` tOpts `deepseq` ()
+  rnf (ForeignKeyAdded tName tCon tOpts) = tName `deepseq` tCon `deepseq` tOpts `deepseq` ()
+  rnf (PrimaryKeyAdded tName tCon tOpts) = tName `deepseq` tCon `deepseq` tOpts `deepseq` ()
   rnf (ColumnAdded tName cName col) = tName `deepseq` cName `deepseq` col `deepseq` ()
   rnf (ColumnRemoved tName colName) = tName `deepseq` colName `deepseq` ()
   rnf (ColumnTypeChanged tName colName c1 c2) = c1 `seq` c2 `seq` tName `deepseq` colName `deepseq` ()
-  rnf (ColumnConstraintAdded tName cName cCon) = tName `deepseq` cName `deepseq` cCon `deepseq` ()
-  rnf (ColumnConstraintRemoved tName colName cCon) = tName `deepseq` colName `deepseq` cCon `deepseq` ()
+  rnf (ColumnNullableChanged tName cName cCon) = tName `deepseq` cName `deepseq` cCon `deepseq` ()
+  rnf (ColumnDefaultChanged _ tName colName cCon) = tName `deepseq` colName `deepseq` cCon `deepseq` ()
   rnf (EnumTypeAdded eName enum) = eName `deepseq` enum `deepseq` ()
   rnf (EnumTypeRemoved eName) = eName `deepseq` ()
   rnf (EnumTypeValueAdded eName inserted order insertionPoint) =
     eName `deepseq` inserted `deepseq` order `deepseq` insertionPoint `deepseq` ()
   rnf (SequenceAdded sName s) = sName `deepseq` s `deepseq` ()
   rnf (SequenceRemoved sName) = sName `deepseq` ()
+  rnf (TableConstraintRemoved tName cName) = tName `deepseq` cName `deepseq` ()
+  rnf (RenameConstraint tName cName cName') = tName `deepseq` cName `deepseq` cName' `deepseq` ()
+  rnf (SequenceRenamed sName sName') = sName `deepseq` sName' `deepseq` ()
+  rnf (SequenceSetOwner sName sOwner) = sName `deepseq` sOwner `deepseq` ()
 
 -- | A possible enumerations of the reasons why a 'diff' operation might not work.
 data DiffError
@@ -365,8 +469,22 @@ instance NFData DiffError
 noSchema :: Schema
 noSchema = Schema mempty mempty mempty
 
-noTableConstraints :: Set TableConstraint
-noTableConstraints = mempty
+noTableConstraints :: TableConstraints
+noTableConstraints = TableConstraints
+  { primaryKeyConstraint = Nothing
+  , foreignKeyConstraints = Map.empty
+  , uniqueConstraints = Map.empty
+  }
 
-noColumnConstraints :: Set ColumnConstraint
-noColumnConstraints = mempty
+noColumnConstraints :: ColumnConstraints
+noColumnConstraints = ColumnConstraints Null Nothing
+
+
+fmap concat $ traverse (makeLensesWith (set lensField (mappingNamer $ pure . ('_':)) defaultFieldRules))
+  [ ''Schema
+  , ''Sequence
+  , ''TableConstraints
+  , ''Table
+  , ''Column
+  , ''ColumnConstraints
+  ]

--- a/src/Database/Beam/AutoMigrate/Types.hs
+++ b/src/Database/Beam/AutoMigrate/Types.hs
@@ -202,9 +202,7 @@ newtype DbEnum a
 newtype ConstraintName = ConstraintName { unConsraintName :: Text }
   deriving (IsString, Eq, Ord, Show, NFData)
 
-data PrimaryKeyConstraint = PrimaryKey
-      -- | This set of 'Column's identifies the Table's 'PrimaryKey'.
-      (Set ColumnName)
+data PrimaryKeyConstraint = PrimaryKey (Set ColumnName) -- ^ This set of 'Column's identifies the Table's 'PrimaryKey'.
   deriving (Eq, Ord, Show, Generic)
 
 
@@ -213,9 +211,9 @@ instance Semigroup PrimaryKeyConstraint where
 
 instance NFData PrimaryKeyConstraint
 
-  -- | This set of 'Column's identifies a Table's 'ForeignKey'. This is usually found in the 'tableConstraints'
-    -- of the table where the foreign key is actually defined (in terms of 'REFERENCES').
-    -- The set stores a (fk_column, pk_column) correspondence.
+-- | This set of 'Column's identifies a Table's 'ForeignKey'. This is usually found in the 'tableConstraints'
+-- of the table where the foreign key is actually defined (in terms of references).
+-- The set stores a (fk_column, pk_column) correspondence.
 data ForeignKey = ForeignKey
   TableName
   (Set (ColumnName, ColumnName))

--- a/src/Database/Beam/AutoMigrate/Types.hs
+++ b/src/Database/Beam/AutoMigrate/Types.hs
@@ -293,6 +293,14 @@ data ManualEditAction
   = ColumnRenamed TableName ColumnName {- old name -} ColumnName {- new name -}
   deriving (Show, Eq)
 
+data TableConstraintRemovedType
+  = TableConstraintRemovedType_PrimaryKey
+  | TableConstraintRemovedType_Unique
+  | TableConstraintRemovedType_ForeignKey
+  deriving (Eq, Ord, Show, Generic)
+
+instance NFData TableConstraintRemovedType
+
 data AutomaticEditAction
   = TableAdded TableName Table
   | TableRemoved TableName
@@ -302,7 +310,7 @@ data AutomaticEditAction
   | UniqueConstraintAdded TableName Unique UniqueConstraintOptions
   | ForeignKeyAdded TableName ForeignKey ForeignKeyConstraintOptions
 
-  | TableConstraintRemoved TableName ConstraintName
+  | TableConstraintRemoved TableName ConstraintName TableConstraintRemovedType
   | RenameConstraint TableName
     ConstraintName {- old name -}
     ConstraintName {- new name -}
@@ -432,7 +440,7 @@ instance NFData AutomaticEditAction where
     eName `deepseq` inserted `deepseq` order `deepseq` insertionPoint `deepseq` ()
   rnf (SequenceAdded sName s) = sName `deepseq` s `deepseq` ()
   rnf (SequenceRemoved sName) = sName `deepseq` ()
-  rnf (TableConstraintRemoved tName cName) = tName `deepseq` cName `deepseq` ()
+  rnf (TableConstraintRemoved tName cName typ) = tName `deepseq` cName `deepseq` typ `deepseq` ()
   rnf (RenameConstraint tName cName cName') = tName `deepseq` cName `deepseq` cName' `deepseq` ()
   rnf (SequenceRenamed sName sName') = sName `deepseq` sName' `deepseq` ()
   rnf (SequenceSetOwner sName sOwner) = sName `deepseq` sOwner `deepseq` ()

--- a/src/Database/Beam/AutoMigrate/Util.hs
+++ b/src/Database/Beam/AutoMigrate/Util.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+{-# OPTIONS_GHC -Wall -Werror #-}
+
 module Database.Beam.AutoMigrate.Util where
 
 import Control.Applicative.Lift
@@ -15,7 +17,7 @@ import qualified Data.Text as T
 import Database.Beam.AutoMigrate.Types (ColumnName(..), TableName(..))
 import qualified Database.Beam.Schema as Beam
 import Database.Beam.Schema.Tables
-import Lens.Micro ((^.))
+import Control.Lens ((^.))
 
 --
 -- Retrieving all the column names for a beam entity.

--- a/src/Database/Beam/AutoMigrate/Util.hs
+++ b/src/Database/Beam/AutoMigrate/Util.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# OPTIONS_GHC -Wall -Werror #-}
-
 module Database.Beam.AutoMigrate.Util where
 
 import Control.Applicative.Lift

--- a/src/Database/Beam/AutoMigrate/Validity.hs
+++ b/src/Database/Beam/AutoMigrate/Validity.hs
@@ -426,7 +426,7 @@ applyEdit s edit@(Edit e _safety) = runExcept $ case e of
       withExistingTable tName edit s (addTableConstraint edit s (SomeUnique con conOpt) tName)
     ForeignKeyAdded tName con conOpt ->
       withExistingTable tName edit s (addTableConstraint edit s (SomeForeignKey con conOpt) tName)
-    TableConstraintRemoved tName con ->
+    TableConstraintRemoved tName con _ ->
       withExistingTable tName edit s (removeTableConstraint edit s con tName)
     RenameConstraint tName oldName newName ->
       withExistingTable tName edit s (renameTableConstraint edit s oldName newName tName)


### PR DESCRIPTION
This PR hopefully improves beam-automigration hadnling of most types of constraint, and in how it handles sequences; so that they can be used in more cases and with fewer surprises.

The main idea is to make the internal types used in beam-automigrate more accurately reflect the kind of changes it can actually do, and to use keys in maps that more usefully reflect the salient parts of the schema.  One rarely cares for the name of a constraint, but only the way that it constrains the data in the database.

Most of the linecount in this PR is working through the fallout of fixing the way beam-automigrate uses set operations to instead use maps as described above.

This has a secondary (benificial?) affect of making beam-automigrate a bit more robust agains superficial differences in the schema, such as when a column is renamed that was used in some constraint; since beam-automigrate now no longer cares what constraints are named.

still TODO

- [x] needs rebased on latest develop branch
- [x] non SERIAL defaults are being reset every time
	- make a real AST for the sql types.
	- "fix" "parser" to expect (and discard) typecasts
	- there are some possibly helpful notes in `getAllDefaults` that might inform a more robust solution.
	- this all probably has to do with whatever pgSerialTyColumnType was doing.
- [ ] document new featues in README
- [x] fix code examples in haddocs to work correctly (particurly in D.B.A.Annotated)
- [x] make tests compile/kinda work
- [ ] sort imports?
- [ ] add constraint key data to `TableConstraintRemoved` to facilitate unsafe migrations when the constraint name is not known at the haskell level.
- [ ] read 'primary key cannot be null' check to validator? (see comment on deleted validateRemoveColumnConstraint)