### PR TITLE
Add vector column type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add ltree column type
+* Add vector column type
 
 ## 0.1.4.0
 

--- a/src/Database/Beam/AutoMigrate.hs
+++ b/src/Database/Beam/AutoMigrate.hs
@@ -571,6 +571,9 @@ renderDataType = \case
   PgSpecificType PgOid -> "oid"
   -- ltree
   PgSpecificType PgLTree -> "ltree"
+  -- vector
+  PgSpecificType (PgVector Nothing) -> "vector"
+  PgSpecificType (PgVector (Just n)) -> mconcat ["vector(", T.pack . show $ n, ")"]
   -- Arrays
   SqlArrayType (SqlArrayType _ _) _ -> error "beam-automigrate: invalid nested array."
   SqlArrayType _ 0 -> error "beam-automigrate: array with zero dimensions"

--- a/src/Database/Beam/AutoMigrate/Types.hs
+++ b/src/Database/Beam/AutoMigrate/Types.hs
@@ -23,6 +23,7 @@ import qualified Database.Beam.Backend.SQL.AST as AST
 import Database.Beam.Postgres (Pg, Postgres)
 import qualified Database.Beam.Postgres.Syntax as Syntax
 import GHC.Generics hiding (to)
+import Numeric.Natural (Natural)
 import Lens.Micro (Lens', lens, to, _Right)
 import Lens.Micro.Extras (preview)
 
@@ -158,12 +159,21 @@ data PgDataType
   | PgEnumeration EnumerationName
   | PgOid
   | PgLTree
+  | PgVector (Maybe Natural)
 
 deriving instance Show PgDataType
 
 deriving instance Eq PgDataType
 
 deriving instance Generic PgDataType
+
+newtype ExtensionTypeName = ExtensionTypeName
+  { extensionTypeName :: Text
+  }
+  deriving (Show, Eq, Ord, NFData, Generic)
+
+instance IsString ExtensionTypeName where
+  fromString = ExtensionTypeName . T.pack
 
 -- Newtype wrapper to be able to derive appropriate 'HasDefaultSqlDataType' for /Postgres/ enum types.
 newtype PgEnum a


### PR DESCRIPTION
This is for use with the pgvector extension, which allows us to store / index / query text embeddings for various machine learning tasks.