### PR TITLE
allow compilation with GHC 9.10

### DIFF
--- a/beam-automigrate.cabal
+++ b/beam-automigrate.cabal
@@ -40,7 +40,7 @@ library
 
   hs-source-dirs:     src
   build-depends:
-      aeson                 >=1.4.4    && <2.2
+      aeson                 >=1.4.4    && <2.3
     , base                  >=4.9      && <5
     , beam-core             >=0.9      && <0.11
     , beam-postgres         >=0.5      && <0.6
@@ -50,9 +50,9 @@ library
     , dlist                 >=0.8.0    && <1.1
     , microlens             >=0.4.10   && <0.6
     , mtl                   >=2.2.2    && <2.4
-    , postgresql-simple     >=0.5.4    && <0.7.0.0
+    , postgresql-simple     >=0.5.4    && <0.7.1.0
     , pretty-simple         >=2.2.0    && <4.2
-    , QuickCheck            >=2.13     && <2.15
+    , QuickCheck            >=2.13     && <2.18
     , quickcheck-instances  >=0.3      && <0.4
     , scientific            >=0.3.6    && <0.5
     , splitmix              >=0.0.3    && <0.2
@@ -61,7 +61,7 @@ library
     , time                  >=1.8.0    && <2
     , transformers          >=0.5.6    && <0.7
     , uuid                  >=1.3      && <1.4
-    , vector                >=0.12.0.3 && <0.13.0.0
+    , vector                >=0.12.0.3 && <0.14.0.0
 
   default-language:   Haskell2010
   default-extensions:

--- a/src/Database/Beam/AutoMigrate.hs
+++ b/src/Database/Beam/AutoMigrate.hs
@@ -60,6 +60,7 @@ module Database.Beam.AutoMigrate
 where
 
 import Control.Exception
+import Control.Monad (when, forM_)
 import Control.Monad.Except
 import Control.Monad.Identity (runIdentity)
 import Control.Monad.State.Strict

--- a/src/Database/Beam/AutoMigrate/Postgres.hs
+++ b/src/Database/Beam/AutoMigrate/Postgres.hs
@@ -10,6 +10,7 @@ module Database.Beam.AutoMigrate.Postgres
   )
 where
 
+import Control.Monad (guard)
 import Control.Monad.State
 import Data.Bits (shiftR, (.&.))
 import Data.ByteString (ByteString)

--- a/src/Database/Beam/AutoMigrate/Util.hs
+++ b/src/Database/Beam/AutoMigrate/Util.hs
@@ -5,6 +5,7 @@ module Database.Beam.AutoMigrate.Util where
 
 import Control.Applicative.Lift
 import Control.Monad.Except
+import Control.Monad.Trans.Class (lift)
 import Data.Char
 import Data.Functor.Constant
 import Data.Set (Set)


### PR DESCRIPTION
I have:
* run cabal build locally with ghc 9.10
* run cabal test locally with ghc 9.01
* run nix-build release.nix

They all passed. Not sure if we will warnings on older versions because of the new imports, but the release test passed, so hopefully nothing too serious.

My local env is nixos unstable, 
ghc --version
The Glorious Glasgow Haskell Compilation System, version 9.10.3
cabal --version
cabal-install version 3.16.0.0 
